### PR TITLE
HTC-135: added script to run tests in client project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - 'stable'
 install: npm install
+env:
+  - TEST_DIR=client
+script: npm install && npm test && cd $TEST_DIR && npm install && npm test


### PR DESCRIPTION
# [Issue 135](https://github.com/rachellegelden/Home-Together-Canada/issues/135)

## Summary
Turned off npm caching for Travis CI. https://docs.travis-ci.com/user/languages/javascript-with-nodejs/ 

## Relevant Motivation & Context
It is causing TravisCI builds to fail

## Testing Instructions
We will be able to test this PR after it is merged and Travis CI does a new build of develop

## Developer checklist prior to opening this pull request:

- [ ] PR merges to the applicable branch (develop or feature branch)
- [ ] Commits adhere to GitHub compliance (Issue #)
- [ ] Comments for non-trivial changes
- [ ] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [ ] Unit tests pass
- [ ] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
