### PR TITLE
HTC-61: updated ESlinter's config, removed unused code

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -23,7 +23,8 @@
     ],
     "rules": {
         "react/jsx-uses-react": "warn",
-        "react/jsx-uses-vars": "warn"
+        "react/jsx-uses-vars": "warn",
+        "no-unused-vars": "warn"
     },
     "settings": {
         "react": {

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,13 +1,4 @@
-// import App from './App';
-// import React from 'react';
-// import {toBeInTheDocument, toHaveClass} from '@testing-library/jest-dom'
-
-// test('renders learn react link', () => {
-//   render(<App />);
-//   const linkElement = screen.getByText(/learn react/i);
-//   expect(linkElement).toBeInTheDocument();
-// });
-
+// dummy test
 describe("test suite", () => {
   it("test 1", () => {
       expect(true).toBe(true);


### PR DESCRIPTION
# [Issue 61](https://github.com/rachellegelden/Home-Together-Canada/issues/61)

## Summary
Updated ESlinter's config:
`no-unused-vars` is now sending a `warn` instead of `error`.

## Relevant Motivation & Context
ESlinter was blocking compiling due to unused variables. This change will allow the linter to send a warning but not block. For future reference, check https://eslint.org/docs/rules/ to learn more about the rules/warnings/errors

## Testing Instructions
To test, pull this branch, add an unused var or import statement to a file and check if ESLint is sending a `warn` or `error`. It should not be sending an error due to `no-unused-vars`.

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [x] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
