### PR TITLE
HTC-176: removed personal config file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@ src/tailwind.output.css
 # production
 /client/build
 
-# development
-/server/personalConfig
-
 # misc
 .DS_Store
 **/.DS_Store

--- a/server/personalConfig/personalDbConfig.js
+++ b/server/personalConfig/personalDbConfig.js
@@ -1,0 +1,30 @@
+module.exports = {
+    development: {
+        HOST: "127.0.0.1",
+        USER: "root",
+        PASSWORD: "m/A38-m[hL?5eST^",
+        DB: "hometogethercanadadatabase",
+        DIALECT: "mysql",
+        POOL: {
+            max: 5,
+            min: 0,
+            acquire: 30000,
+            idle: 10000
+        },
+        PORT: 3306
+    },
+    test: {
+        HOST: "127.0.0.1",
+        USER: "root",
+        PASSWORD: "m/A38-m[hL?5eST^",
+        DB: "hometogethercanadadatabase_test",
+        DIALECT: "mysql",
+        POOL: {
+            max: 5,
+            min: 0,
+            acquire: 30000,
+            idle: 10000
+        },
+        PORT: 3306
+    }
+}


### PR DESCRIPTION
# [176](https://github.com/rachellegelden/Home-Together-Canada/issues/176)

## Summary
Removed the personalConfig file from `.gitignore` and checked it into our repo

## Relevant Motivation & Context
The Heroku app wasn't serving the files due to this error:
![image](https://user-images.githubusercontent.com/43148498/98711810-55d48b00-233a-11eb-882f-6083db9f203f.png)

## Testing Instructions
Merging the PR then checking if the Heroku app launches correctly

## Developer checklist prior to opening this pull request:

- [ ] PR merges to the applicable branch (develop or feature branch)
- [ ] Commits adhere to GitHub compliance (Issue #)
- [ ] Comments for non-trivial changes
- [ ] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [ ] Unit tests pass
- [ ] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [x] Review code structure
- [x] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
