### PR TITLE
HTC-176: re-added personalConfig folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ src/tailwind.output.css
 # production
 /client/build
 
+# development
+/server/personalConfig
+
 # misc
 .DS_Store
 **/.DS_Store


### PR DESCRIPTION
# [176](https://github.com/rachellegelden/Home-Together-Canada/issues/176)

## Summary
Re-added personalConfig folder to .gitignore

## Relevant Motivation & Context
So that we aren't committing our DB credentials

## Testing Instructions
N/A

## Developer checklist prior to opening this pull request:

- [ ] PR merges to the applicable branch (develop or feature branch)
- [ ] Commits adhere to GitHub compliance (Issue #)
- [ ] Comments for non-trivial changes
- [ ] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [ ] Unit tests pass
- [ ] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
