### PR TITLE
HTC-306: fixed crash caused by invalid group member usernames

### DIFF
--- a/client/src/common/forms/ShareLimits.js
+++ b/client/src/common/forms/ShareLimits.js
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import Dropdown from "./Dropdown";
 import propTypes from "prop-types";
 

--- a/client/src/common/forms/Status.js
+++ b/client/src/common/forms/Status.js
@@ -1,7 +1,3 @@
-import React, {useState} from 'react';
-import propTypes from "prop-types";
-import Dropdown from "./Dropdown";
-
 /**
  * @Author:     Parsa Rajabi
  * @Created:    2020.11.23
@@ -10,6 +6,9 @@ import Dropdown from "./Dropdown";
  *
  */
 
+import React from 'react';
+import propTypes from "prop-types";
+import Dropdown from "./Dropdown";
 
 const statuses = [
     {

--- a/client/src/registration/MemberRegistrationForm.js
+++ b/client/src/registration/MemberRegistrationForm.js
@@ -263,8 +263,10 @@ function MemberRegistrationForm(props) {
             ...(gender === 'Other') && {genderDescription: gender},
             birthYear: yearOfBirth,
             status: selectedStatus,
-            ...((selectedStatus === 'Couple' || selectedStatus === 'Couple With Children') && !isStringEmpty(partner))&& {partnerUsername: partner},
-            ...(selectedStatus === 'Existing Group') && {existingGroupUsernames: groupMembers.split(',').map(item => item.trim())},
+            ...((selectedStatus === 'Couple' || selectedStatus === 'Couple With Children') && !isStringEmpty(partner))
+                && {partnerUsername: partner},
+            ...(selectedStatus === 'Existing Group' && !isStringEmpty(groupMembers))
+                && {existingGroupUsernames: groupMembers.split(',').map(item => item.trim())},
             minMonthlyBudget: minRent,
             maxMonthlyBudget: maxRent,
             hasHomeToShare: (hasHome === 'yes'),

--- a/server/controllers/validators/userControllerValidator.js
+++ b/server/controllers/validators/userControllerValidator.js
@@ -297,16 +297,15 @@ exports.validate = (method) => {
                     .stripLow()
                     .custom(partnerUsername => usernameShouldExistAndBeAMember(partnerUsername))
                     .custom((partnerUsername, { req }) => linkedMemberShouldHaveSameStatus(partnerUsername, req)),
-                body('existingGroupUsernames', `A valid member's username must be provided for existing group members`)
+                body('existingGroupUsernames')
+                    .optional()
+                    .isArray(),
+                body('existingGroupUsernames.*')
                     .optional()
                     .trim()
                     .stripLow()
-                    .custom(existingGroupUsernames => existingGroupUsernames.forEach(username =>
-                       usernameShouldExistAndBeAMember(username)
-                    ))
-                    .custom((existingGroupUsernames, { req }) => existingGroupUsernames.forEach(username =>
-                        linkedMemberShouldHaveSameStatus(username, req)
-                    )),
+                    .custom(username => usernameShouldExistAndBeAMember(username))
+                    .custom((username, { req }) => linkedMemberShouldHaveSameStatus(username, req)),
                 body('areasOfInterest')
                     .exists()
                     .isArray()


### PR DESCRIPTION
# [HTC-306](https://github.com/rachellegelden/Home-Together-Canada/issues/306)

## Summary
When providing an invalid username for a member in an existing group, the server would crash. This happened both through the React app and through Postman

## Relevant Motivation & Context
We should be able to recover from invalid data

## Testing Instructions
Create a few accounts and link them together as an existing group by providing their usernames in the registration form. Make sure that if you provide invalid data, you get an error back and can try again

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [x] Checkout and launch this branch locally
- [x] Review code structure
- [x] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
