### PR TITLE
HTC-318: Optimized Tailwind CSS from 2.1 MB to 28 KB

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
   },
   purge: {
     enabled: true,


### PR DESCRIPTION
# [Issue 318](https://github.com/rachellegelden/Home-Together-Canada/issues/318)

closes #318 

## Summary
Optimized Tailwind CSS from `2.1 MB` to `28 KB` by purging unused CSS 
Guide: [Optimizing Tailwind](https://tailwindcss.com/docs/optimizing-for-production)

## Relevant Motivation & Context
Optimization of code and space on the production server

## Testing Instructions
- checkout to branch 
- comment out line 7 in `tailwind.config.js` (`enabled: true`)
- run `npm start` in client 
- check how many lines of code `tailwind.output.css` has (should be `93985`)
- in your project directory, check the file size of `tailwind.output.css` (should be `2.1 MB`)
- stop the server 
- uncomment line 7 in `tailwind.config.js` (`enabled: true`)
- run `npm start` in client 
- check how many lines of code `tailwind.output.css` has (should be `1815`)
- in your project directory, check the file size of `tailwind.output.css` (should be `28 KB`)
- Done :) 


## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
