### PR TITLE
HTC-353: Work Status - Other input field

### DIFF
--- a/client/src/registration/MemberRegistrationForm.js
+++ b/client/src/registration/MemberRegistrationForm.js
@@ -93,6 +93,7 @@ function MemberRegistrationForm(props) {
 
     const [selectedFamilyStatus, setsSelectedFamilyStatus] = useState();
     const [selectedWorkStatus, setsSelectedWorkStatus] = useState();
+    const [workStatus, setWorkStatus] = useState("");
 
     const [partner, setPartner] = useState("");
     const [groupMembers, setGroupMembers] = useState("");
@@ -103,7 +104,7 @@ function MemberRegistrationForm(props) {
         radius: ""
     }]);
 
-    function checkStatus(selectedFamilyStatus) {
+    function checkFamilyStatus(selectedFamilyStatus) {
         if (selectedFamilyStatus === "Couple") {
             return <TextArea
                 className={"input"}
@@ -129,7 +130,18 @@ function MemberRegistrationForm(props) {
                 value={groupMembers}
             />
         }
+    }
 
+    //TODO: ensure DB can handle this new change of "other" Work Status
+    function checkWorkStatus(selectedWorkStatus) {
+        if (selectedWorkStatus === "Other") {
+            return <TextArea
+                className={"input"}
+                placeholder="Elaborate (optional)"
+                onChange={(e) => setWorkStatus(e.target.value)}
+                value={workStatus}
+            />
+        }
     }
 
     const handleFamilyStatusChange = e => {
@@ -437,10 +449,11 @@ function MemberRegistrationForm(props) {
                                         </div>
                                         <label className={"label"}> Status </label>
                                         <Status onChange={handleFamilyStatusChange}/>
-                                        {checkStatus(selectedFamilyStatus)}
+                                        {checkFamilyStatus(selectedFamilyStatus)}
 
                                         <label className={"label"}> Work Status </label>
                                         <WorkStatus onChange={handleWorkStatusChange}/>
+                                        {checkWorkStatus(selectedWorkStatus)}
 
                                         <label className={"label text-base "}> open to sharing with </label>
                                         <ShareLimit onChange={handleLimitChange}/>


### PR DESCRIPTION
# [Issue 353](https://github.com/rachellegelden/Home-Together-Canada/issues/353)

closes #353 

## Summary
- Added ability for the user to input a work status in the other field that pops up after they select other from the dropdown

## Relevant Motivation & Context
- Consistency across the page

## Testing Instructions
- Go to member reg. 
- Select "other" from work status dropdown
- ensure a new value input pops below it

Note: If this looks good, we need to create another issue to ensure DB / backend can handle this new input 

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [x] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
