### PR TITLE
HTC-198: initial redux store with user privileges

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.5.0",
         "@testing-library/jest-dom": "^5.11.5",
         "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
@@ -19,10 +20,12 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-icons": "^4.1.0",
+        "react-redux": "^7.2.2",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.0",
         "react-select": "^3.1.0",
         "react-test-renderer": "^17.0.1",
+        "redux": "^4.0.5",
         "tailwindcss": "^1.9.6",
         "web-vitals": "^0.2.4"
       },
@@ -2371,6 +2374,26 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.5.0.tgz",
+      "integrity": "sha512-E/FUraRx+8guw9Hlg/Ja8jI/hwCrmIKed8Annt9YsZw3BQp+F24t5I5b2OWR6pkEHY4hn1BgP08FrTZFRKsdaQ==",
+      "dependencies": {
+        "immer": "^8.0.0",
+        "redux": "^4.0.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.0.tgz",
+      "integrity": "sha512-jm87NNBAIG4fHwouilCHIecFXp5rMGkiFrAuhVO685UnMAlOneEAnOyzPt8OnP47TC11q/E7vpzZe0WvwepFTg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -20702,6 +20725,30 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
+      "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17",
+        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -21459,6 +21506,20 @@
         "postcss-value-parser": "^3.3.0"
       }
     },
+    "node_modules/redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz",
@@ -21766,6 +21827,11 @@
       "resolved": "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "node_modules/resolve": {
       "version": "1.19.0",
@@ -23700,6 +23766,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -27864,6 +27938,24 @@
           "version": "0.7.3",
           "resolved": "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
+    "@reduxjs/toolkit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.5.0.tgz",
+      "integrity": "sha512-E/FUraRx+8guw9Hlg/Ja8jI/hwCrmIKed8Annt9YsZw3BQp+F24t5I5b2OWR6pkEHY4hn1BgP08FrTZFRKsdaQ==",
+      "requires": {
+        "immer": "^8.0.0",
+        "redux": "^4.0.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.0.tgz",
+          "integrity": "sha512-jm87NNBAIG4fHwouilCHIecFXp5rMGkiFrAuhVO685UnMAlOneEAnOyzPt8OnP47TC11q/E7vpzZe0WvwepFTg=="
         }
       }
     },
@@ -40985,6 +41077,18 @@
       "resolved": "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-redux": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
+      "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      }
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -41538,6 +41642,20 @@
         "postcss-value-parser": "^3.3.0"
       }
     },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz",
@@ -41757,6 +41875,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.19.0",
@@ -43179,6 +43302,11 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.5.0",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -15,10 +16,12 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-icons": "^4.1.0",
+    "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "react-select": "^3.1.0",
     "react-test-renderer": "^17.0.1",
+    "redux": "^4.0.5",
     "tailwindcss": "^1.9.6",
     "web-vitals": "^0.2.4"
   },

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,25 +9,35 @@ import MemberRegistrationForm from "./registration/MemberRegistrationForm";
 import BusinessRegistration from './registration/BusinessRegistrationForm';
 import Error404 from './common/error/Error404'
 import {BrowserRouter as Router, Switch, Route} from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import rootReducer from './redux/reducers';
+
+const store = configureStore({
+    reducer: rootReducer
+});
 
 function App() {
     return (
-        <Router>
-        <div>
-            <Header/>
-            {/* Matches the URL to the path and does not go through the rest of the routes*/}
-            <Switch>
-                {/* Renders the correct component based on the URL*/}
-                <Route path={"/"} exact component={Home}/>
-                <Route path={"/login"} component={Login}/>
-                <Route path={"/registration/business"} component={BusinessRegistration}/>
-                <Route path={"/registration/member"} component={MemberRegistrationForm}/>
-                <Route path={"/registration"} component={MainLandingPage}/>
-                <Route component={Error404} />
-            </Switch>
-            <Footer/>
-        </div>
-        </Router>
+        <Provider store={store}>
+            <Router>
+                <div>
+                    <Header/>
+                    {/* Matches the URL to the path and does not go through the rest of the routes*/}
+                    <Switch>
+                        {/* Renders the correct component based on the URL*/}
+                        <Route path={"/"} exact component={Home}/>
+                        <Route path={"/login"} component={Login}/>
+                        <Route path={"/registration/business"} component={BusinessRegistration}/>
+                        <Route path={"/registration/member"} component={MemberRegistrationForm}/>
+                        <Route path={"/registration"} component={MainLandingPage}/>
+                        <Route component={Error404} />
+                    </Switch>
+                    <Footer/>
+                </div>
+            </Router>
+        </Provider>
+
     );
 }
 

--- a/client/src/common/header-and-footer/Header.js
+++ b/client/src/common/header-and-footer/Header.js
@@ -11,13 +11,23 @@ import '../../tailwind.output.css';
 import {Link} from "react-router-dom";
 import LoginService from '../../services/LoginService';
 import Button from "../forms/Button";
+import {connect} from "react-redux";
+import {setAccountType, setAuthenticated, setIsAdmin} from "../../redux/slices/userPrivileges";
+import PropTypes from "prop-types";
 
-const Header = () => {
+const mapDispatch = { setIsAdmin, setAccountType, setAuthenticated };
+
+const Header = (props) => {
+
+    const { setIsAdmin, setAccountType, setAuthenticated } = props;
 
     const logout = () => {
         LoginService.logoutUser()
             .then(res => res.json())
             .then(() => {
+                setIsAdmin({ isAdmin: false });
+                setAccountType({ accountType: null });
+                setAuthenticated({ authenticated: false });
                 alert('You have been logged out.')
             })
     }
@@ -85,4 +95,10 @@ const Header = () => {
     )
 }
 
-export default Header;
+Header.propTypes = {
+    setAccountType: PropTypes.func,
+    setIsAdmin: PropTypes.func,
+    setAuthenticated: PropTypes.func
+}
+
+export default connect(null, mapDispatch) (Header);

--- a/client/src/login/LoginForm.js
+++ b/client/src/login/LoginForm.js
@@ -18,9 +18,13 @@ import {Link} from 'react-router-dom';
 import LoginService from '../services/LoginService';
 import {getConcatenatedErrorMessage} from "../registration/registrationUtils";
 import PropTypes from "prop-types";
+import { connect } from 'react-redux';
+import {setIsAdmin, setAccountType, setAuthenticated} from "../redux/slices/userPrivileges";
+
+const mapDispatch = { setIsAdmin, setAccountType, setAuthenticated };
 
 function LoginForm(props) {
-    const { history } = props;
+    const { history, setIsAdmin, setAccountType, setAuthenticated } = props;
 
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
@@ -53,6 +57,21 @@ function LoginForm(props) {
             .then(data => {
                 if (!!data && data.authenticated) {
                     alert('Successful login!');
+                    // dispatch action to set isAdmin
+                    setIsAdmin({isAdmin: data.member ? data.member.isAdmin : false});
+
+                    // dispatch action to set accountType
+                    let accountType = null;
+                    if (data.member) {
+                        accountType = 'member';
+                    } else if (data.business) {
+                        accountType = 'business';
+                    }
+                    setAccountType({accountType});
+
+                    // dispatch action to set authenticated
+                    setAuthenticated({ authenticated: data.authenticated });
+
                     // user is authenticated, redirect to home screen
                     return history.push('/');
                 } else if (!!data && !data.authenticated) {
@@ -125,7 +144,10 @@ function LoginForm(props) {
 LoginForm.propTypes = {
     history: PropTypes.shape({
         push: PropTypes.func
-    })
+    }),
+    setAccountType: PropTypes.func,
+    setIsAdmin: PropTypes.func,
+    setAuthenticated: PropTypes.func
 }
 
-export default LoginForm;
+export default connect(null, mapDispatch) (LoginForm);

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -1,0 +1,15 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2020.12.19
+ *
+ * @Description: root reducer for redux store
+ *
+ */
+
+import { combineReducers } from 'redux';
+
+import userPrivilegesReducer from '../slices/userPrivileges';
+
+export default combineReducers({
+    userPrivileges: userPrivilegesReducer
+});

--- a/client/src/redux/slices/userPrivileges.js
+++ b/client/src/redux/slices/userPrivileges.js
@@ -1,0 +1,42 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2020.12.19
+ *
+ * @Description: slice with reducers and actions for user privileges
+ *
+ * Tutorials used: https://www.valentinog.com/blog/redux/ & https://redux-toolkit.js.org/tutorials/intermediate-tutorial
+ *
+ */
+
+import { createSlice } from '@reduxjs/toolkit';
+
+const userPrivilegesSlice = createSlice({
+    name: 'privileges',
+    initialState: {
+        isAdmin: false,
+        accountType: null,
+        authenticated: null
+    },
+    reducers: {
+        setIsAdmin(state, action) {
+            const { isAdmin } = action.payload;
+            state.isAdmin = isAdmin;
+        },
+        setAccountType(state, action) {
+            const { accountType } = action.payload;
+            state.accountType = accountType;
+        },
+        setAuthenticated(state, action) {
+            const { authenticated } = action.payload;
+            state.authenticated = authenticated;
+        }
+    }
+});
+
+export const {
+    setIsAdmin,
+    setAccountType,
+    setAuthenticated
+} = userPrivilegesSlice.actions;
+
+export default userPrivilegesSlice.reducer;

--- a/client/src/registration/BusinessRegistrationForm.js
+++ b/client/src/registration/BusinessRegistrationForm.js
@@ -19,10 +19,15 @@ import {isStringEmail, isStringEmpty, isStringSame, isStringNumeralsOnly} from "
 import RegistrationService from '../services/RegistrationService';
 import {getConcatenatedErrorMessage, getPhoneNumberFromStrings} from "./registrationUtils";
 import Asterisk from "../common/forms/Asterisk";
+import { connect } from 'react-redux';
+import {setAccountType, setAuthenticated} from '../redux/slices/userPrivileges';
+
+const mapDispatch = { setAccountType, setAuthenticated };
+
 
 // TODO: separate this into container and presentational components (see https://css-tricks.com/learning-react-container-components/)
 const BusinessRegistrationForm = (props) => {
-    const {history} = props;
+    const {history, setAccountType, setAuthenticated} = props;
 
     const [useDifferentMailingAddress, setUseDifferentMailingAddress] = useState(false);
     const [isNationWide, setIfNationWide] = useState(false);
@@ -254,6 +259,14 @@ const BusinessRegistrationForm = (props) => {
             .then(res => res.json())
             .then(data => {
                 if (!!data && data.authenticated) {
+                    // dispatch action to set accountType
+                    if (data.business) {
+                        setAccountType({accountType: 'business'});
+                    }
+
+                    // dispatch action to set authenticated
+                    setAuthenticated({ authenticated: data.authenticated });
+
                     // user is authenticated, redirect to home screen
                     alert('Business account successfully created!');
                     return history.push('/');
@@ -405,8 +418,7 @@ const BusinessRegistrationForm = (props) => {
                         <label className="label">
                             Business Logo
                         </label>
-                        <div
-                            className="flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
+                        <div className="flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
                             <div className="space-y-1 text-center">
                                 <svg className="w-12 h-12 mx-auto text-gray-400" stroke="currentColor"
                                      fill="none" viewBox="0 0 48 48" aria-hidden="true">
@@ -443,8 +455,7 @@ const BusinessRegistrationForm = (props) => {
                         </p>
                     </div>
                 </div>
-                <div
-                    className="mt-5 md:mt-0 md:col-span-2 shadow sm:rounded-md sm:overflow-hidden px-4 py-5 space-y-1 bg-white sm:p-6">
+                <div className="mt-5 md:mt-0 md:col-span-2 shadow sm:rounded-md sm:overflow-hidden px-4 py-5 space-y-1 bg-white sm:p-6">
                     <div className="grid grid-cols-6 gap-x-6">
                         <div className="column-span-6-layout">
                             <TextArea className={"input"}
@@ -528,7 +539,9 @@ const BusinessRegistrationForm = (props) => {
 BusinessRegistrationForm.propTypes = {
     history: PropTypes.shape({
         push: PropTypes.func
-    })
+    }),
+    setAccountType: PropTypes.func,
+    setAuthenticated: PropTypes.func
 }
 
-export default BusinessRegistrationForm;
+export default connect(null, mapDispatch) (BusinessRegistrationForm);

--- a/client/src/registration/MemberRegistrationForm.js
+++ b/client/src/registration/MemberRegistrationForm.js
@@ -27,10 +27,14 @@ import PropTypes from "prop-types";
 import WorkStatus from "../common/forms/WorkStatus";
 import Asterisk from "../common/forms/Asterisk";
 import LabelAsterisk from "../common/forms/LabelAsterisk";
+import { connect } from 'react-redux';
+import {setIsAdmin, setAccountType, setAuthenticated} from '../redux/slices/userPrivileges';
+
+const mapDispatch = { setIsAdmin, setAccountType, setAuthenticated };
 
 //Returns a Form with fields
 function MemberRegistrationForm(props) {
-    const {history} = props;
+    const { history, setIsAdmin, setAccountType, setAuthenticated } = props;
     const [firstName, setFirstName] = useState("");
     const [lastName, setLastName] = useState("");
     const [yearOfBirth, setYearOfBirth] = useState("");
@@ -299,13 +303,23 @@ function MemberRegistrationForm(props) {
             areasOfInterest: areasOfInterest,
         }
 
-        console.log('registration data: ', registrationData);
-
         RegistrationService.registerMemberUser(registrationData)
             .then(res => res.json())
             .then(data => {
                 if (!!data && data.authenticated) {
                     alert('Member account successfully created!');
+
+                    // dispatch action to set isAdmin
+                    setIsAdmin({isAdmin: data.member ? data.member.isAdmin : false});
+
+                    // dispatch action to set accountType
+                    if (data.member) {
+                        setAccountType({accountType: 'member'});
+                    }
+
+                    // dispatch action to set authenticated
+                    setAuthenticated({ authenticated: data.authenticated });
+
                     // user is authenticated, redirect to home screen
                     return history.push('/');
                 } else if (!!data && data.errors && data.errors.length) {
@@ -336,8 +350,7 @@ function MemberRegistrationForm(props) {
                         </p>
                     </div>
                 </div>
-                <div
-                    className="mt-5 md:mt-0 md:col-span-2 shadow sm:rounded-md sm:overflow-hidden px-4 py-5 space-y-1 bg-white sm:p-6">
+                <div className="mt-5 md:mt-0 md:col-span-2 shadow sm:rounded-md sm:overflow-hidden px-4 py-5 space-y-1 bg-white sm:p-6">
                     <div className="grid grid-cols-2 gap-6">
                         <div className="col-span-3 sm:col-span-2">
                             <TextArea
@@ -677,7 +690,10 @@ function MemberRegistrationForm(props) {
 MemberRegistrationForm.propTypes = {
     history: PropTypes.shape({
         push: PropTypes.func
-    })
+    }),
+    setAccountType: PropTypes.func,
+    setIsAdmin: PropTypes.func,
+    setAuthenticated: PropTypes.func
 }
 
-export default MemberRegistrationForm;
+export default connect(null, mapDispatch) (MemberRegistrationForm);

--- a/client/src/registration/__tests__/BusinessRegistrationForm.test.js
+++ b/client/src/registration/__tests__/BusinessRegistrationForm.test.js
@@ -2,13 +2,20 @@ import React from 'react';
 import renderer from  'react-test-renderer'
 import BusinessRegistrationForm from "../BusinessRegistrationForm";
 
+jest.mock('react-redux', () => ({
+    connect: () => {
+        return (component) => {
+            return component
+        };
+    }
+}));
+
 describe('BusinessRegistrationForm', () => {
-    describe('Snapshot test', () => {
-        it("should render correctly regardless of properties", () => {
-            //when
-            const component = renderer.create(<BusinessRegistrationForm/>).toJSON();
-            //then
-            expect(component).toMatchSnapshot();
-        });
-    })
+    it("should render correctly regardless of properties", () => {
+        //when
+        const component = renderer.create(<BusinessRegistrationForm/>);
+        const tree = component.toJSON();
+        //then
+        expect(tree).toMatchSnapshot();
+    });
 })

--- a/client/src/registration/__tests__/MemberRegistrationForm.test.js
+++ b/client/src/registration/__tests__/MemberRegistrationForm.test.js
@@ -7,16 +7,22 @@
  */
 import React from 'react';
 import renderer from  'react-test-renderer'
-import { BrowserRouter as Router } from 'react-router-dom';
 import MemberRegistrationForm from "../MemberRegistrationForm";
 
+jest.mock('react-redux', () => ({
+    connect: () => {
+        return (component) => {
+            return component
+        };
+    }
+}));
+
 describe('MemberProfileForm', () => {
-    describe('Snapshot test', () => {
-        it("should render correctly regardless of properties", () => {
-            //when
-            const component = renderer.create(<MemberRegistrationForm />).toJSON();
-            //then
-            expect(component).toMatchSnapshot();
-        });
-    })
+    it("should render correctly regardless of properties", () => {
+        //when
+        const component = renderer.create(<MemberRegistrationForm />);
+        const tree = component.toJSON();
+        //then
+        expect(tree).toMatchSnapshot();
+    });
 })

--- a/client/src/registration/__tests__/__snapshots__/BusinessRegistrationForm.test.js.snap
+++ b/client/src/registration/__tests__/__snapshots__/BusinessRegistrationForm.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BusinessRegistrationForm Snapshot test should render correctly regardless of properties 1`] = `
+exports[`BusinessRegistrationForm should render correctly regardless of properties 1`] = `
 <div>
   <div>
     <div

--- a/client/src/registration/__tests__/__snapshots__/MemberRegistrationForm.test.js.snap
+++ b/client/src/registration/__tests__/__snapshots__/MemberRegistrationForm.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MemberProfileForm Snapshot test should render correctly regardless of properties 1`] = `
+exports[`MemberProfileForm should render correctly regardless of properties 1`] = `
 <div>
   <div
     className="m-10 md:grid md:grid-cols-4 md:gap-0"

--- a/server/controllers/businessAccountController.js
+++ b/server/controllers/businessAccountController.js
@@ -46,7 +46,12 @@ const findAllBusinessAccounts = (req, res) => {
         });
 }
 
+const findBusinessByUid = (uid) => {
+    return BusinessAccount.findByPk(uid);
+}
+
 module.exports = {
     createBusinessAccount,
-    findAllBusinessAccounts
+    findAllBusinessAccounts,
+    findBusinessByUid
 }

--- a/server/controllers/memberAccountController.js
+++ b/server/controllers/memberAccountController.js
@@ -69,8 +69,13 @@ const findMemberAccountByUsername = (username) => {
     })
 }
 
+const findMemberAccountByUid = uid => {
+    return MemberAccount.findByPk(uid);
+}
+
 module.exports = {
     createMemberAccount,
     findAllMemberAccounts,
-    findMemberAccountByUsername
+    findMemberAccountByUsername,
+    findMemberAccountByUid
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -65,7 +65,7 @@ router.post('/business/create/', usersValidator.validate('createBusinessUser'),
         } else {
             passport.authenticate('local-signup-business', {
                 // change these routes to ones that send actual response data
-                successRedirect: '/checkAuth',
+                successRedirect: '/successfulLogin/',
                 failureRedirect: '/checkAuth',
                 failureFlash: false })(req, res, next);
         }
@@ -80,7 +80,7 @@ router.post('/member/create/', usersValidator.validate('createMemberUser'),
             } else {
                 passport.authenticate('local-signup-member', {
                     // change these routes to ones that send actual response data
-                    successRedirect: '/checkAuth',
+                    successRedirect: '/successfulLogin/',
                     failureRedirect: '/checkAuth',
                     failureFlash: false })(req, res, next);
             }
@@ -120,13 +120,36 @@ router.post("/login/user/", usersValidator.validate('loginUser'),
         } else {
             passport.authenticate('local-signin',
                 {
-                    successRedirect: '/checkAuth',
+                    successRedirect: '/successfulLogin/',
                     failureRedirect: '/checkAuth',
                     failureFlash: false
                 })(req, res, next);
         }
     }
 );
+
+router.get('/successfulLogin/', async function (req, res, next) {
+    const uid = req.user.uid;
+
+    const member = await memberAccounts.findMemberAccountByUid(uid);
+    const business = await businessAccounts.findBusinessByUid(uid);
+
+    if (!member && !business) {
+        res.status(202).json({error: 'cannot find user'});
+    } else {
+        let responseData = {
+            user: {...req.user},
+            authenticated: true
+        };
+
+        if (member) {
+            responseData.member = { ...member.dataValues };
+        } else {
+            responseData.business = { ...business.dataValues };
+        }
+        res.status(200).json(responseData);
+    }
+});
 
 function isLoggedIn(req, res, next) {
     if (req.isAuthenticated())


### PR DESCRIPTION
# [HTC-198](https://github.com/rachellegelden/Home-Together-Canada/issues/198)

## Summary
- created a redux store for react-app https://redux.js.org/api/store
- as of right now, it is storing the users privileges (isAdmin, accountType and authenticated)
- updated the route that successful logins/registrations are directed to. This was done to ensure that the information that is to be stored in the redux store is passed to the front-end.
- when a user logs or registers in, the values listed above are set accordingly in the redux store 
- when the user logs out, these values will be changed back to their default values

## Relevant Motivation & Context
This will be required to manage the state on the front-end of the application. This will let us implement things such as a dynamic header and account summaries

## Testing Instructions
1. install the following chrome plugin - [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
2. run `npm install` in the `client` folder
3. in Chrome DevTools, navigate to the Redux tab and then go to state
![image](https://user-images.githubusercontent.com/43148498/102705531-e9548200-423d-11eb-8101-ccc05d1b31f5.png)
4. Keep this open then go through the registration processes for members and businesses, login for members and businesses and logging out in between everything. Ensure that the values in the state update as expected

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [x] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [x] Checkout and launch this branch locally
- [x] Review code structure
- [x] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
