### PR TITLE
HTC-211: dynamic header with tests

### DIFF
--- a/client/src/common/constants/users.js
+++ b/client/src/common/constants/users.js
@@ -1,0 +1,51 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2020.12.20
+ *
+ * @Description: constants used for users
+ *
+ */
+
+export const USER_TYPES = {
+    MEMBER: 'member',
+    BUSINESS: 'business',
+    UNREGISTERED: null
+}
+
+export const MEMBER_SUBPAGES = [
+    {
+        label: 'Account Info',
+        value: 'Account Info'
+    },
+    {
+        label: 'Profile',
+        value: 'Profile'
+    },
+    {
+        label: 'Password',
+        value: 'Password'
+    },
+    {
+        label: 'Messaging',
+        value: 'Messaging'
+    },
+    {
+        label: 'Manage Listings',
+        value: 'Manage Listings'
+    }
+];
+
+export const BUSINESS_SUBPAGES = [
+    {
+        label: 'Account Info',
+        value: 'Account Info'
+    },
+    {
+        label: 'Password',
+        value: 'Password'
+    },
+    {
+        label: 'Manage Listings',
+        value: 'Manage Listings'
+    }
+]

--- a/client/src/common/forms/Dropdown.js
+++ b/client/src/common/forms/Dropdown.js
@@ -11,9 +11,9 @@ import Select from 'react-select';
 import propTypes from "prop-types";
 
 function Dropdown(props) {
-    const {isSearchable, name, placeholder, options, onChange} = props;
+    const {isSearchable, name, placeholder, options, onChange, intialSelection} = props;
 
-    const [selected, setSelected] = useState("");
+    const [selected, setSelected] = useState(intialSelection || "");
 
     // this code is run every time selected changes
     useEffect(() => {
@@ -37,20 +37,23 @@ function Dropdown(props) {
 
     return (
         <div>
-            <Select isSearchable={isSearchable} placeholder={placeholder}
-                    options={options} value={options.find(obj => obj.label === selected)}
-                    onChange={(e) => setSelected(e)}
-                    name={name}
-                    menuPortalTarget={document.body}
-                    styles={newStyling}
-                    theme={theme => ({
-                        ...theme,
-                        borderRadius: 8,
-                        colors: {
-                            ...theme.colors,
-                            neutral50: '#A0AEBF',  // Placeholder color
-                        }
-                    })}
+            <Select
+                isSearchable={isSearchable}
+                placeholder={placeholder}
+                options={options}
+                value={options.find(obj => obj.label === selected)}
+                onChange={(e) => setSelected(e)}
+                name={name}
+                menuPortalTarget={document.body}
+                styles={newStyling}
+                theme={theme => ({
+                    ...theme,
+                    borderRadius: 8,
+                    colors: {
+                        ...theme.colors,
+                        neutral50: '#A0AEBF',  // Placeholder color
+                    }
+                })}
             />
         </div>
     );
@@ -61,7 +64,8 @@ Dropdown.propTypes = {
     name: propTypes.string,
     isSearchable: propTypes.bool,
     placeholder: propTypes.string,
-    onChange: propTypes.func
+    onChange: propTypes.func,
+    intialSelection: propTypes.string
 };
 
 export default Dropdown;

--- a/client/src/common/header-and-footer/Header.js
+++ b/client/src/common/header-and-footer/Header.js
@@ -14,19 +14,28 @@ import Button from "../forms/Button";
 import {connect} from "react-redux";
 import {setAccountType, setAuthenticated, setIsAdmin} from "../../redux/slices/userPrivileges";
 import PropTypes from "prop-types";
+import {BUSINESS_SUBPAGES, MEMBER_SUBPAGES, USER_TYPES} from "../constants/users";
+import Dropdown from "../forms/Dropdown";
 
 const mapDispatch = { setIsAdmin, setAccountType, setAuthenticated };
 
 const Header = (props) => {
 
-    const { setIsAdmin, setAccountType, setAuthenticated } = props;
+    const {
+        setIsAdmin,
+        setAccountType,
+        setAuthenticated,
+        isAdmin,
+        accountType,
+        authenticated
+    } = props;
 
     const logout = () => {
         LoginService.logoutUser()
             .then(res => res.json())
             .then(() => {
                 setIsAdmin({ isAdmin: false });
-                setAccountType({ accountType: null });
+                setAccountType({ accountType: USER_TYPES.UNREGISTERED });
                 setAuthenticated({ authenticated: false });
                 alert('You have been logged out.')
             })
@@ -52,10 +61,12 @@ const Header = (props) => {
                     <div
                         className="flex-no-wrap hidden w-full p-4 mt-2 tex-black lg:flex lg:items-center lg:w-auto lg:block lg:mt-0 lg:bg-transparent lg:p-0">
                         <div className="items-center justify-end flex-1 mr-16 list-reset lg:flex">
+                            {accountType !== USER_TYPES.BUSINESS &&
                             <Link to={'/members'}
                                   className="inline-block px-4 py-2 mr-3 transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50">
                                 Connect with Members
                             </Link>
+                            }
                             <Link to={'/services'}
                                   className="inline-block px-4 py-2 mr-3 transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50">
                                 Services
@@ -72,20 +83,47 @@ const Header = (props) => {
                                   className="inline-block px-4 py-2 mr-3 no-underline transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50">
                                 FAQ
                             </Link>
+                            {(authenticated && accountType !== USER_TYPES.UNREGISTERED) &&
+                                < Link to={'/create/listing'}
+                                    className="inline-block px-4 py-2 mr-3 no-underline transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50">
+                                    Create Listing
+                                </Link>
+                            }
+                            {(authenticated && isAdmin) &&
+                                <Link to={'/admin'}
+                                      className="inline-block px-4 py-2 mr-3 no-underline transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50">
+                                    Admin
+                                </Link>
+                            }
                         </div>
 
                         {/* Login and Sign Up Buttons */}
-                        <Link to={'/login'}
-                              className="items-center justify-center w-full px-6 py-2 mr-4 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 hover:bg-orange-400">Login
-                        </Link>
-                        <Link to={'/registration'}
-                              className="items-center justify-center w-full px-4 py-2 mr-4 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 hover:bg-orange-400">Sign
-                            Up
-                        </Link>
-                        <Button
-                            className="outline-none	items-center justify-center w-full px-4 py-2 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 cursor-pointer hover:bg-orange-400"
-                            value={'Logout'}
-                            onClick={logout}/>
+                        {(accountType === USER_TYPES.UNREGISTERED || !authenticated) &&
+                            <Link to={'/login'}
+                                  className="items-center justify-center w-full px-6 py-2 mr-4 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 hover:bg-orange-400">Login
+                            </Link>
+                        }
+                        {(accountType === USER_TYPES.UNREGISTERED || !authenticated) &&
+                            <Link to={'/registration'}
+                                  className="items-center justify-center w-full px-4 py-2 mr-4 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 hover:bg-orange-400">Sign
+                                Up
+                            </Link>
+                        }
+                        {authenticated &&
+                            <Button
+                                className="outline-none	items-center justify-center w-full px-4 py-2 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 cursor-pointer hover:bg-orange-400"
+                                value={'Logout'}
+                                onClick={logout}
+                            />
+                        }
+                        {(authenticated || accountType !== USER_TYPES.UNREGISTERED) &&
+                        <Dropdown
+                            options={accountType === USER_TYPES.MEMBER ? MEMBER_SUBPAGES : BUSINESS_SUBPAGES}
+                            onChange={() => null}
+                            placeholder={'Account'}
+                            name={'Account'}
+                        />
+                        }
                     </div>
                 </div>
                 {/*Bottom Border*/}
@@ -95,10 +133,19 @@ const Header = (props) => {
     )
 }
 
+const mapStateToProps = (state) => ({
+    isAdmin: state.userPrivileges.isAdmin,
+    accountType: state.userPrivileges.accountType,
+    authenticated: state.userPrivileges.authenticated
+});
+
 Header.propTypes = {
-    setAccountType: PropTypes.func,
-    setIsAdmin: PropTypes.func,
-    setAuthenticated: PropTypes.func
+    setAccountType: PropTypes.func.isRequired,
+    setIsAdmin: PropTypes.func.isRequired,
+    setAuthenticated: PropTypes.func.isRequired,
+    isAdmin: PropTypes.bool.isRequired,
+    authenticated: PropTypes.bool.isRequired,
+    accountType: PropTypes.string
 }
 
-export default connect(null, mapDispatch) (Header);
+export default connect(mapStateToProps, mapDispatch) (Header);

--- a/client/src/common/header-and-footer/__tests__/Header.test.js
+++ b/client/src/common/header-and-footer/__tests__/Header.test.js
@@ -1,0 +1,579 @@
+import React from 'react';
+import renderer from  'react-test-renderer'
+import Header from "../Header";
+import {BrowserRouter, Link} from "react-router-dom";
+
+jest.mock('react-redux', () => ({
+    connect: () => {
+        return (component) => {
+            return component
+        };
+    }
+}));
+
+const setAccountType = jest.fn();
+const setIsAdmin = jest.fn();
+const setAuthenticated = jest.fn();
+
+describe('Header', () => {
+    describe('Header structure', () => {
+        it('should match snapshot test', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+            //when
+            const component = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>);
+            const tree = component.toJSON();
+            //then
+            expect(tree).toMatchSnapshot();
+        });
+    });
+
+    describe('Connect with Members button', () => {
+        it('should show Connect with Members button when the user is unregistered', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const connectWithMembersButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Connect with Members');
+
+            // then
+            expect(connectWithMembersButton).toBeDefined();
+        });
+        it('should show Connect with Members button when the user is a member', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const connectWithMembersButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Connect with Members');
+
+            // then
+            expect(connectWithMembersButton).toBeDefined();
+        });
+        it('should not show Connect with Members button when the user is a business', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'business',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const connectWithMembersButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Connect with Members');
+
+            // then
+            expect(connectWithMembersButton).toBeUndefined();
+        });
+    });
+
+    describe('Services button', () => {
+        it('should show Services button when the user is unregistered', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const servicesButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Services');
+
+            // then
+            expect(servicesButton).toBeDefined();
+        });
+        it('should show Services button when the user is a member', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const servicesButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Services');
+
+            // then
+            expect(servicesButton).toBeDefined();
+        });
+        it('should show Services button when the user is a business', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'business',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const servicesButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Services');
+
+            expect(servicesButton).toBeDefined();
+        });
+    });
+
+    describe('Classifieds button', () => {
+        it('should show Classifieds button when the user is unregistered', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const classifiedsButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Classifieds');
+
+            // then
+            expect(classifiedsButton).toBeDefined();
+        });
+        it('should show Classifieds button when the user is a member', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const classifiedsButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Classifieds');
+
+            // then
+            expect(classifiedsButton).toBeDefined();
+        });
+        it('should show Classifieds button when the user is a business', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'business',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const classifiedsButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Classifieds');
+
+            // then
+            expect(classifiedsButton).toBeDefined();
+        });
+    });
+
+    describe('About Us button', () => {
+        it('should show About Us button when the user is unregistered', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const aboutUsButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'About Us');
+
+            // then
+            expect(aboutUsButton).toBeDefined();
+        });
+        it('should show About Us button when the user is a member', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const aboutUsButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'About Us');
+
+            // then
+            expect(aboutUsButton).toBeDefined();
+        });
+        it('should show About Us button when the user is a business', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'business',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const aboutUsButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'About Us');
+
+            // then
+            expect(aboutUsButton).toBeDefined();
+        });
+    });
+
+    describe('FAQ button', () => {
+        it('should show FAQ button when the user is unregistered', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const faqButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'FAQ');
+
+            // then
+            expect(faqButton).toBeDefined();
+        });
+        it('should show FAQ button when the user is a member', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const faqButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'FAQ');
+
+            // then
+            expect(faqButton).toBeDefined();
+        });
+        it('should show FAQ button when the user is a business', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'business',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const faqButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'FAQ');
+
+            // then
+            expect(faqButton).toBeDefined();
+        });
+    });
+
+    describe('Create Listing button', () => {
+        it('should show not show Create Listing button when the user is unregistered', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const createListingButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Create Listing');
+
+            // then
+            expect(createListingButton).toBeUndefined();
+        });
+        it('should show Create Listing button when the user is a member', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const createListingButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Create Listing');
+
+            // then
+            expect(createListingButton).toBeDefined();
+        });
+        it('should show Create Listing button when the user is a business', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'business',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const createListingButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Create Listing');
+
+            // then
+            expect(createListingButton).toBeDefined();
+        });
+    });
+
+    describe('Admin button', () => {
+        it('should show not show Admin button when the user is unauthenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const adminButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Admin');
+
+            // then
+            expect(adminButton).toBeUndefined();
+        });
+        it('should show not Admin button when isAdmin is false', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const adminButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Admin');
+
+            // then
+            expect(adminButton).toBeUndefined();
+        });
+        it('should show Admin button when the user is authenticated and isAdmin is true', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: true,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const adminButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Admin');
+
+            // then
+            expect(adminButton).toBeDefined();
+        });
+    });
+
+    describe('Login button', () => {
+        it('should show Login button when the user is unauthenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const loginButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Login');
+
+            // then
+            expect(loginButton).toBeDefined();
+        });
+        it('should not show Login button when user is authenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const loginButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Login');
+
+            // then
+            expect(loginButton).toBeUndefined();
+        });
+    });
+
+    describe('Sign Up button', () => {
+        it('should show Sign Up button when the user is unauthenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const signupButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Sign Up');
+
+            // then
+            expect(signupButton).toBeDefined();
+        });
+        it('should not show Sign Up button when user is authenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const signupButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Sign Up');
+
+            // then
+            expect(signupButton).toBeUndefined();
+        });
+    });
+
+    describe('Logout button', () => {
+        it('should not show Logout button when the user is unauthenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: null,
+                authenticated: false
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const logoutButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Logout');
+
+            // then
+            expect(logoutButton).toBeUndefined();
+        });
+        it('should show Logout button when user is authenticated', () => {
+            // given
+            const props = {
+                setAccountType,
+                setIsAdmin,
+                setAuthenticated,
+                isAdmin: false,
+                accountType: 'member',
+                authenticated: true
+            };
+
+            // when
+            const testInstance = renderer.create(<BrowserRouter><Header {...props}/></BrowserRouter>).root;
+            const logoutButton = testInstance.findAllByType(Link)
+                .find(element => element.props.children === 'Logout');
+
+            // then
+            expect(logoutButton).toBeUndefined();
+        });
+    });
+});

--- a/client/src/common/header-and-footer/__tests__/__snapshots__/Header.test.js.snap
+++ b/client/src/common/header-and-footer/__tests__/__snapshots__/Header.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header Header structure should match snapshot test 1`] = `
+<div>
+  <nav
+    className="top-0 flex w-full bg-green-400 tex-black"
+  >
+    <div
+      className="container flex items-center justify-between w-full py-2 mx-auto mt-0 whitespace-no-wrap"
+    >
+      <div
+        className="flex flex-no-wrap items-center ml-4"
+      >
+        <a
+          className="text-lg font-bold lg:text-xl"
+          href="/"
+          onClick={[Function]}
+        >
+          Home Together Canada
+        </a>
+      </div>
+      <div
+        className="flex-no-wrap hidden w-full p-4 mt-2 tex-black lg:flex lg:items-center lg:w-auto lg:block lg:mt-0 lg:bg-transparent lg:p-0"
+      >
+        <div
+          className="items-center justify-end flex-1 mr-16 list-reset lg:flex"
+        >
+          <a
+            className="inline-block px-4 py-2 mr-3 transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50"
+            href="/members"
+            onClick={[Function]}
+          >
+            Connect with Members
+          </a>
+          <a
+            className="inline-block px-4 py-2 mr-3 transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50"
+            href="/services"
+            onClick={[Function]}
+          >
+            Services
+          </a>
+          <a
+            className="inline-block px-4 py-2 mr-3 transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50"
+            href="/classifieds"
+            onClick={[Function]}
+          >
+            Classifieds
+          </a>
+          <a
+            className="inline-block px-4 py-2 mr-3 transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50"
+            href="/about"
+            onClick={[Function]}
+          >
+            About Us
+          </a>
+          <a
+            className="inline-block px-4 py-2 mr-3 no-underline transition duration-200 ease-in-out border-transparent rounded-md hover:bg-white hover:text-black hover:opacity-50"
+            href="/faq"
+            onClick={[Function]}
+          >
+            FAQ
+          </a>
+        </div>
+        <a
+          className="items-center justify-center w-full px-6 py-2 mr-4 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 hover:bg-orange-400"
+          href="/login"
+          onClick={[Function]}
+        >
+          Login
+        </a>
+        <a
+          className="items-center justify-center w-full px-4 py-2 mr-4 transition duration-200 ease-in-out bg-white border-transparent rounded-md opacity-75 hover:bg-orange-400"
+          href="/registration"
+          onClick={[Function]}
+        >
+          Sign Up
+        </a>
+      </div>
+    </div>
+    <hr
+      className="py-0 my-0 border-b border-gray-200 opacity-25"
+    />
+  </nav>
+</div>
+`;

--- a/client/src/login/LoginForm.js
+++ b/client/src/login/LoginForm.js
@@ -20,6 +20,7 @@ import {getConcatenatedErrorMessage} from "../registration/registrationUtils";
 import PropTypes from "prop-types";
 import { connect } from 'react-redux';
 import {setIsAdmin, setAccountType, setAuthenticated} from "../redux/slices/userPrivileges";
+import {USER_TYPES} from "../common/constants/users";
 
 const mapDispatch = { setIsAdmin, setAccountType, setAuthenticated };
 
@@ -63,9 +64,9 @@ function LoginForm(props) {
                     // dispatch action to set accountType
                     let accountType = null;
                     if (data.member) {
-                        accountType = 'member';
+                        accountType = USER_TYPES.MEMBER;
                     } else if (data.business) {
-                        accountType = 'business';
+                        accountType = USER_TYPES.BUSINESS;
                     }
                     setAccountType({accountType});
 
@@ -142,12 +143,12 @@ function LoginForm(props) {
 }
 
 LoginForm.propTypes = {
+    setAccountType: PropTypes.func.isRequired,
+    setIsAdmin: PropTypes.func.isRequired,
+    setAuthenticated: PropTypes.func.isRequired,
     history: PropTypes.shape({
         push: PropTypes.func
-    }),
-    setAccountType: PropTypes.func,
-    setIsAdmin: PropTypes.func,
-    setAuthenticated: PropTypes.func
+    })
 }
 
 export default connect(null, mapDispatch) (LoginForm);

--- a/client/src/registration/BusinessRegistrationForm.js
+++ b/client/src/registration/BusinessRegistrationForm.js
@@ -21,6 +21,7 @@ import {getConcatenatedErrorMessage, getPhoneNumberFromStrings} from "./registra
 import Asterisk from "../common/forms/Asterisk";
 import { connect } from 'react-redux';
 import {setAccountType, setAuthenticated} from '../redux/slices/userPrivileges';
+import {USER_TYPES} from "../common/constants/users";
 
 const mapDispatch = { setAccountType, setAuthenticated };
 
@@ -261,7 +262,7 @@ const BusinessRegistrationForm = (props) => {
                 if (!!data && data.authenticated) {
                     // dispatch action to set accountType
                     if (data.business) {
-                        setAccountType({accountType: 'business'});
+                        setAccountType({accountType: USER_TYPES.BUSINESS});
                     }
 
                     // dispatch action to set authenticated
@@ -537,11 +538,11 @@ const BusinessRegistrationForm = (props) => {
 }
 
 BusinessRegistrationForm.propTypes = {
+    setAccountType: PropTypes.func.isRequired,
+    setAuthenticated: PropTypes.func.isRequired,
     history: PropTypes.shape({
         push: PropTypes.func
-    }),
-    setAccountType: PropTypes.func,
-    setAuthenticated: PropTypes.func
+    })
 }
 
 export default connect(null, mapDispatch) (BusinessRegistrationForm);

--- a/client/src/registration/MemberRegistrationForm.js
+++ b/client/src/registration/MemberRegistrationForm.js
@@ -29,6 +29,7 @@ import Asterisk from "../common/forms/Asterisk";
 import LabelAsterisk from "../common/forms/LabelAsterisk";
 import { connect } from 'react-redux';
 import {setIsAdmin, setAccountType, setAuthenticated} from '../redux/slices/userPrivileges';
+import {USER_TYPES} from "../common/constants/users";
 
 const mapDispatch = { setIsAdmin, setAccountType, setAuthenticated };
 
@@ -314,7 +315,7 @@ function MemberRegistrationForm(props) {
 
                     // dispatch action to set accountType
                     if (data.member) {
-                        setAccountType({accountType: 'member'});
+                        setAccountType({accountType: USER_TYPES.MEMBER});
                     }
 
                     // dispatch action to set authenticated
@@ -688,12 +689,12 @@ function MemberRegistrationForm(props) {
 }
 
 MemberRegistrationForm.propTypes = {
+    setAccountType: PropTypes.func.isRequired,
+    setIsAdmin: PropTypes.func.isRequired,
+    setAuthenticated: PropTypes.func.isRequired,
     history: PropTypes.shape({
         push: PropTypes.func
-    }),
-    setAccountType: PropTypes.func,
-    setIsAdmin: PropTypes.func,
-    setAuthenticated: PropTypes.func
+    })
 }
 
 export default connect(null, mapDispatch) (MemberRegistrationForm);

--- a/client/src/registration/__tests__/BusinessRegistrationForm.test.js
+++ b/client/src/registration/__tests__/BusinessRegistrationForm.test.js
@@ -10,10 +10,18 @@ jest.mock('react-redux', () => ({
     }
 }));
 
+const setAccountType = jest.fn();
+const setAuthenticated = jest.fn();
+
 describe('BusinessRegistrationForm', () => {
     it("should render correctly regardless of properties", () => {
+        // given
+        const props = {
+            setAccountType,
+            setAuthenticated
+        };
         //when
-        const component = renderer.create(<BusinessRegistrationForm/>);
+        const component = renderer.create(<BusinessRegistrationForm {...props}/>);
         const tree = component.toJSON();
         //then
         expect(tree).toMatchSnapshot();

--- a/client/src/registration/__tests__/MemberRegistrationForm.test.js
+++ b/client/src/registration/__tests__/MemberRegistrationForm.test.js
@@ -17,10 +17,20 @@ jest.mock('react-redux', () => ({
     }
 }));
 
+const setAccountType = jest.fn();
+const setIsAdmin = jest.fn();
+const setAuthenticated = jest.fn();
+
 describe('MemberProfileForm', () => {
     it("should render correctly regardless of properties", () => {
+        // given
+        const props = {
+            setAccountType,
+            setIsAdmin,
+            setAuthenticated
+        };
         //when
-        const component = renderer.create(<MemberRegistrationForm />);
+        const component = renderer.create(<MemberRegistrationForm {...props}/>);
         const tree = component.toJSON();
         //then
         expect(tree).toMatchSnapshot();


### PR DESCRIPTION
# [HTC-211](https://github.com/rachellegelden/Home-Together-Canada/issues/211)

## Summary
The header will now change dynamically depending on whether the user is authenticated, a member vs business, and an admin

## Relevant Motivation & Context
Feedback to the user about the status of the application

## Testing Instructions
Try logging in and out with different types of accounts

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [x] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
