### PR TITLE
HTC-381: add check for banned users during login

### DIFF
--- a/client/src/login/LoginForm.js
+++ b/client/src/login/LoginForm.js
@@ -74,9 +74,10 @@ function LoginForm(props) {
 
                     // user is authenticated, redirect to home screen
                     return history.push('/');
+
                 } else if (!!data && !data.authenticated) {
                     // something went wrong with authentication
-                    alert('Login failed');
+                    alert('Login failed. Please try again and contact Home Together if the issue persists.');
                 } else if (!!data && data.errors && data.errors.length) {
                     const errorMessage = getConcatenatedErrorMessage(data.errors);
                     // show list of all errors

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -151,6 +151,12 @@ module.exports = function (passport) {
                     });
                 }
 
+                if (user.isBanned) {
+                    return done(null, false, {
+                        message: 'Account is frozen. Please contact Home Together Canada for more information.'
+                    });
+                }
+
                 const userinfo = user.get();
                 return done(null, userinfo);
 


### PR DESCRIPTION
# [381](https://github.com/rachellegelden/Home-Together-Canada/issues/381)

## Summary
Added a check for user to make sure the user isn't banned when they login

## Relevant Motivation & Context
Keep nefarious users off the site

## Testing Instructions
Change `user.isBanned` on line `server/config/passport.js:154` to true to mock having a banned user. Ensure a generic alert is shown

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [ ] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
