### PR TITLE
HTC-408: added route and service for business account info

### DIFF
--- a/client/src/services/BusinessService.js
+++ b/client/src/services/BusinessService.js
@@ -1,0 +1,19 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.01.18
+ *
+ * @Description: service used to make API calls related to businesses
+ *
+ */
+
+let DEV_URL = '';
+if (process.env.NODE_ENV === 'development') {
+    DEV_URL = 'http://localhost:3001';
+}
+
+const getBusinessAccountInfo = () =>
+    fetch(`${DEV_URL}/business/info/`, {
+        method: 'GET',
+        withCredentials: true,
+        credentials: 'include'
+    });

--- a/server/routes.js
+++ b/server/routes.js
@@ -29,22 +29,6 @@ router.get('/memberAccount/all/', function (req, res, next) {
     memberAccounts.findAllMemberAccounts(req, res);
 });
 
-// Create a business user
-router.post('/business/create/', usersValidator.validate('createBusinessUser'),
-    function (req, res, next) {
-        const errors = validationResult(req);
-
-        if (!errors.isEmpty()) {
-            res.status(202).json({ errors: errors.array()});
-        } else {
-            passport.authenticate('local-signup-business', {
-                // change these routes to ones that send actual response data
-                successRedirect: '/user/successfulLogin/',
-                failureRedirect: '/user/checkAuth/',
-                failureFlash: false })(req, res, next);
-        }
-});
-
 router.post('/member/create/', usersValidator.validate('createMemberUser'),
     function (req, res, next) {
         const errors = validationResult(req);


### PR DESCRIPTION
# [HTC-408](https://github.com/rachellegelden/Home-Together-Canada/issues/408)

## Summary
Added a route and service that will be used by the client to request a business' information to be displayed on their account summary page

## Relevant Motivation & Context
In order to allow businesses to view their account info

## Testing Instructions
1. Create a business using Postman
2. Ping `http://localhost:3001/business/info` with a `GET` request and make sure that you can fetch the businesses info
3. Attempt to ping the route above when you aren't logged in or you are logged in as a member

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
