### PR TITLE
HTC-466/467: routes to update member account and profile

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,12 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ],
+    "@babel/preset-react"]
 }

--- a/client/src/registration/__tests__/BusinessRegistrationForm.test.js
+++ b/client/src/registration/__tests__/BusinessRegistrationForm.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import renderer from 'react-test-renderer'
 import BusinessRegistrationForm from "../BusinessRegistrationForm";
 import { BrowserRouter as Router } from 'react-router-dom';
-import MemberRegistrationForm from "../MemberRegistrationForm";
 
 
 jest.mock("react-tooltip/node_modules/uuid", () => ({

--- a/server/app.js
+++ b/server/app.js
@@ -50,7 +50,7 @@ require("./config/passport.js")(passport);
 
 
 // force false will prevent the database from being cleared everytime the server starts up
-db.sequelize.sync({ force: false })
+db.sequelize.sync({ force: true })
     .then(() => {
       console.log("Drop and re-sync db.");
     })

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -72,11 +72,11 @@ module.exports = function (passport) {
                     if (req.body.partnerUsername) {
                         abstractUserController.findUserByUsername(req.body.partnerUsername)
                             .then(partnerUser => {
-                                if (partnerUser.length) {
-                                    memberAccount.addRoommate(partnerUser[0].uid,
+                                if (partnerUser) {
+                                    memberAccount.addRoommate(partnerUser.uid,
                                         {
                                             through: {
-                                                relationship: 'partner'
+                                                relationship: req.body.status
                                             }
                                         });
                                 }
@@ -86,10 +86,10 @@ module.exports = function (passport) {
                         req.body.existingGroupUsernames.forEach(username => {
                             abstractUserController.findUserByUsername(username)
                                 .then(roommate => {
-                                    memberAccount.addRoommate(roommate[0].uid,
+                                    memberAccount.addRoommate(roommate.uid,
                                         {
                                             through: {
-                                                relationship: 'roommate'
+                                                relationship: req.body.status
                                             }
                                         });
                                 });

--- a/server/constants/memberConstants.js
+++ b/server/constants/memberConstants.js
@@ -1,0 +1,19 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.01.29
+ *
+ * @Description: constants related to members
+ *
+ */
+
+const STATUS = {
+    SINGLE: 'Single',
+    COUPLE: 'Couple',
+    COUPLE_WITH_CHILDREN: 'Couple With Children',
+    SINGLE_PARENT: 'Single Parent',
+    EXISTING_GROUP: 'Existing Group'
+}
+
+module.exports = {
+    STATUS
+}

--- a/server/controllers/abstractUserController.js
+++ b/server/controllers/abstractUserController.js
@@ -40,12 +40,19 @@ const createAbstractUser = (req, res) => {
 
 const findAbstractUser = (id) => AbstractUser.findByPk(id);
 
-const findUserByUsername = (username) =>
+const findUsersByUsernames = (usernames) =>
     AbstractUser.findAll({
+        where: {
+            username: usernames
+        }
+    });
+
+const findUserByUsername = username =>
+    AbstractUser.findOne({
         where: {
             username: username
         }
-    });
+    })
 
 const findUserByEmail = (email) =>
     AbstractUser.findAll({
@@ -104,6 +111,7 @@ module.exports = {
     findAllAbstractUsers,
     findAbstractUser,
     findUserByUsername,
+    findUsersByUsernames,
     findUserByEmail,
     changePassword,
     updateAbstractUser

--- a/server/controllers/areaOfInterestController.js
+++ b/server/controllers/areaOfInterestController.js
@@ -12,14 +12,46 @@ const AreaOfInterest = db.areaOfInterest;
 const createAreaOfInterest = (areaOfInterest, uid) => {
 
     // TODO: add geocoding to determine lat. and long. coordinates
-    const areaOfInterstEntry = {
+    const areaOfInterestEntry = {
         uid: uid,
         province: areaOfInterest.province,
         city: areaOfInterest.city,
         radius: areaOfInterest.radius
     }
 
-    return AreaOfInterest.create(areaOfInterstEntry);
+    return AreaOfInterest.create(areaOfInterestEntry);
+}
+
+const updateAreaOfInterest = (areaOfInterest, uid) => {
+    return AreaOfInterest.update(
+        {
+            province: areaOfInterest.province,
+            city: areaOfInterest.city,
+            radius: areaOfInterest.radius
+        },
+        {
+            where: { uid: uid }
+        }
+    );
+}
+
+const deleteAreaOfInterest = (areaOfInterest, uid) => {
+    return AreaOfInterest.destroy({
+        where: {
+            uid: uid,
+            province: areaOfInterest.province,
+            city: areaOfInterest.city,
+            radius: areaOfInterest.radius
+        }
+    });
+}
+
+const findAreasOfInterestForUser = uid => {
+    return AreaOfInterest.findAll({
+        where: {
+            uid: uid
+        }
+    });
 }
 
 const findAllAreasOfInterestsForAllUsers = (req, res) => {
@@ -32,5 +64,8 @@ const findAllAreasOfInterestsForAllUsers = (req, res) => {
 
 module.exports = {
     createAreaOfInterest,
-    findAllAreasOfInterestsForAllUsers
+    findAllAreasOfInterestsForAllUsers,
+    updateAreaOfInterest,
+    deleteAreaOfInterest,
+    findAreasOfInterestForUser
 }

--- a/server/controllers/businessAccountController.js
+++ b/server/controllers/businessAccountController.js
@@ -5,8 +5,6 @@
  * @Description: controller functions for BusinessAccount model
  *
  */
-const {Op} = require('sequelize');
-
 const db = require("../models");
 const { formatPhoneNumber } = require('./utils/accountControllerUtils');
 const BusinessAccount = db.businessAccount;

--- a/server/controllers/livesWithController.js
+++ b/server/controllers/livesWithController.js
@@ -6,9 +6,9 @@
  *
  */
 
+const { QueryTypes } = require('sequelize');
 
 const db = require("../models");
-
 const LivesWith = db.livesWith;
 
 const findAllRoommates = (req, res) => {
@@ -19,6 +19,29 @@ const findAllRoommates = (req, res) => {
         }));
 }
 
+const findMemberRoommatesInfo = (uid) => {
+    // was unable to perform query using sequelize functions
+    return db.sequelize.query(
+        'SELECT MemberAccountUid, RoommateUid, username as ?' +
+        'FROM LivesWiths JOIN AbstractUsers ON LivesWiths.RoommateUid = AbstractUsers.uid ' +
+        'WHERE MemberAccountUid = ?',
+        {
+            replacements: ['roommateUsername', uid],
+            type: QueryTypes.SELECT
+        }
+    )
+}
+
+const deleteAllOfAMembersRoommate = uid => {
+    return LivesWith.destroy({
+        where: {
+            MemberAccountUid: uid
+        }
+    })
+}
+
 module.exports = {
-    findAllRoommates
+    findAllRoommates,
+    findMemberRoommatesInfo,
+    deleteAllOfAMembersRoommate
 }

--- a/server/controllers/utils/__tests__/accountControllerUtils.test.js
+++ b/server/controllers/utils/__tests__/accountControllerUtils.test.js
@@ -47,6 +47,19 @@ describe('accountControllerUtils', () => {
         });
     });
 
+    describe('getValueOfOptionalField', () => {
+        it.each`
+            flag    | optionalField | expected
+            ${true} | ${1}          | ${1}
+            ${true} | ${undefined}  | ${undefined}
+            ${false}| ${1}          | ${null}
+            ${false}| ${undefined}  | ${null}
+        `('returns $expected when $flag and optionalField are provided',
+            ({ flag, optionalField, expected }) => {
+                expect(accountControllerUtils.getValueOfOptionalField(flag, optionalField)).toEqual(expected)
+            });
+    });
+
     describe('formatPhoneNumber', () => {
         it('should return a formatted phone number given a valid phone number', () => {
             // expected result

--- a/server/controllers/utils/__tests__/areaOfInterestUtils.test.js
+++ b/server/controllers/utils/__tests__/areaOfInterestUtils.test.js
@@ -1,0 +1,208 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.01.29
+ *
+ * @Description: tests for areas of interest utils
+ *
+ */
+
+
+const { getListOfAreaOfInterestObjects, areasOfInterestHaveChanged } = require('../areaOfInterestUtils');
+
+describe('areaOfInterestUtils', () => {
+    describe('getListOfAreaOfInterestObjects', () => {
+        it('given a list of areas of interest, it should return a new list of objects with only the province, ' +
+            'city and radius properties', () => {
+            // expected result
+            const expectedAreasOfInterestObjects = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                },
+                {
+                    province: "SK",
+                    city: "Saskatoon",
+                    radius: 75
+                }
+            ];
+
+            // given
+            const mockAreasOfInterest = [
+                {
+                    id: 1,
+                    uid: 1,
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    id: 2,
+                    uid: 1,
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                },
+                {
+                    id: 3,
+                    uid: 2,
+                    province: "SK",
+                    city: "Saskatoon",
+                    radius: 75
+                }
+            ];
+
+            // when
+            const areasOfInterestObjects = getListOfAreaOfInterestObjects(mockAreasOfInterest);
+
+            // then
+            expect(areasOfInterestObjects).toEqual(expectedAreasOfInterestObjects);
+        });
+        it('should return an empty array if areasOfInterest is undefined', () => {
+            // expected result
+            const expectedAreasOfInterestObjects = [];
+
+            // given
+            const mockAreasOfInterest = undefined;
+
+            // when
+            const areasOfInterestObjects = getListOfAreaOfInterestObjects(mockAreasOfInterest);
+
+            // then
+            expect(areasOfInterestObjects).toEqual(expectedAreasOfInterestObjects);
+        });
+    });
+
+    describe('areasOfInterestHaveChanged', () => {
+        it('should return true when there are items in the old areas of interest that are not in the new areas ' +
+            'of interest', () => {
+            // given
+            const oldAreasOfInterest = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                },
+                {
+                    province: "SK",
+                    city: "Saskatoon",
+                    radius: 75
+                }
+            ];
+
+            const newAreasOfInterest = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                }
+            ];
+
+            // when
+            const hasChanged = areasOfInterestHaveChanged(oldAreasOfInterest, newAreasOfInterest);
+
+            // then
+            expect(hasChanged).toBe(true);
+        });
+        it('should return true when there are items in the new areas of interest that are not in the old areas ' +
+            'of interest', () => {
+            // given
+            const newAreasOfInterest = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                },
+                {
+                    province: "SK",
+                    city: "Saskatoon",
+                    radius: 75
+                }
+            ];
+
+            const oldAreasOfInterest = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                }
+            ];
+
+            // when
+            const hasChanged = areasOfInterestHaveChanged(oldAreasOfInterest, newAreasOfInterest);
+
+            // then
+            expect(hasChanged).toBe(true);
+        });
+        it('should return false when there is no difference in the items that are in the new areas of interest ' +
+            'and old areas of interest', () => {
+            // given
+            const newAreasOfInterest = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                },
+                {
+                    province: "SK",
+                    city: "Saskatoon",
+                    radius: 75
+                }
+            ];
+
+            const oldAreasOfInterest = [
+                {
+                    province: "AB",
+                    city: "Calgary",
+                    radius: 25
+                },
+                {
+                    province: "MB",
+                    city: "Winnipeg",
+                    radius: 50
+                },
+                {
+                    province: "SK",
+                    city: "Saskatoon",
+                    radius: 75
+                }
+            ];
+
+            // when
+            const hasChanged = areasOfInterestHaveChanged(oldAreasOfInterest, newAreasOfInterest);
+
+            // then
+            expect(hasChanged).toBe(false);
+        });
+    });
+});

--- a/server/controllers/utils/__tests__/statusUtils.test.js
+++ b/server/controllers/utils/__tests__/statusUtils.test.js
@@ -1,0 +1,299 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.01.29
+ *
+ * @Description: tests for areas of interest utils
+ *
+ */
+
+const {
+    isStatusWithRoommates,
+    hasPartnerChanged,
+    haveGroupMembersChanged,
+    getRoommatesUsernames,
+    memberHasCoupleStatus,
+    memberHasExistingGroupStatus
+} = require('../statusUtils');
+
+describe('statusUtils', () => {
+    describe('isStatusWithRoommates', () => {
+        it.each`
+            status                      | expected
+            ${'Single'}                 | ${false}
+            ${'Couple'}                 | ${true}
+            ${'Couple With Children'}   | ${true}
+            ${'Single Parent'}          | ${false}
+            ${'Existing Group'}         | ${true}
+        `('returns $expected when status is $status',
+            ({ status, expected }) => {
+                expect(isStatusWithRoommates(status)).toBe(expected);
+            });
+    });
+
+   describe('hasPartnerChanged', () => {
+       it('returns false if member has a partner and the partner has not changed', () => {
+           // given
+           const memberRoommates = [
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 1,
+                    roommateUsername: 'member1'
+                }
+            ];
+
+           const partnerUsername = 'member1';
+
+           // when
+           const hasPartnerChangedBool = hasPartnerChanged(partnerUsername, memberRoommates);
+
+           // then
+           expect(hasPartnerChangedBool).toBe(false);
+       });
+       it('returns true if member has a partner saved as a roommate but the partner username provided is different', () => {
+           // given
+           const memberRoommates = [
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 1,
+                   roommateUsername: 'member1'
+               }
+           ];
+
+           const partnerUsername = 'memberA';
+
+           // when
+           const hasPartnerChangedBool = hasPartnerChanged(partnerUsername, memberRoommates);
+
+           // then
+           expect(hasPartnerChangedBool).toBe(true);
+       });
+       it('returns true if member has no partners saved as a roommate and a partner username has been provided', () => {
+           // given
+           const memberRoommates = [];
+
+           const partnerUsername = 'memberA';
+
+           // when
+           const hasPartnerChangedBool = hasPartnerChanged(partnerUsername, memberRoommates);
+
+           // then
+           expect(hasPartnerChangedBool).toBe(true);
+       });
+       it('returns true if member has a partner saved as a roommate and a partner username has not been provided', () => {
+           // given
+           const memberRoommates = [
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 1,
+                   roommateUsername: 'member1'
+               }
+           ];
+
+           const partnerUsername = undefined;
+
+           // when
+           const hasPartnerChangedBool = hasPartnerChanged(partnerUsername, memberRoommates);
+
+           // then
+           expect(hasPartnerChangedBool).toBe(true);
+       });
+       it('returns false if member has no partners saved as a roommate and a partner username has not been provided', () => {
+           // given
+           const memberRoommates = [];
+
+           const partnerUsername = undefined;
+
+           // when
+           const hasPartnerChangedBool = hasPartnerChanged(partnerUsername, memberRoommates);
+
+           // then
+           expect(hasPartnerChangedBool).toBe(false);
+       });
+   });
+
+   describe('haveGroupMembersChanged', () => {
+       it('returns false if member has a roommates and the roommates have not changed', () => {
+           // given
+           const memberRoommates = [
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 1,
+                   roommateUsername: 'member1'
+               },
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 3,
+                   roommateUsername: 'member3'
+               },
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 4,
+                   roommateUsername: 'member4'
+               }
+           ];
+
+           const groupMembersUsernames = ['member1', 'member3', 'member4'];
+
+           // when
+           const hasGroupMemberChangedBool = haveGroupMembersChanged(groupMembersUsernames, memberRoommates);
+
+           // then
+            expect(hasGroupMemberChangedBool).toBe(false);
+       });
+        it('returns true if member has roommates saved but the roommates usernames provided are different', () => {
+            // given
+            const memberRoommates = [
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 1,
+                    roommateUsername: 'member1'
+                },
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 3,
+                    roommateUsername: 'member3'
+                },
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 4,
+                    roommateUsername: 'member4'
+                }
+            ];
+
+            const groupMembersUsernames = ['memberA', 'memberB', 'memberC'];
+
+            // when
+            const haveGroupMembersChangedBool = haveGroupMembersChanged(groupMembersUsernames, memberRoommates);
+
+            // then
+            expect(haveGroupMembersChangedBool).toBe(true);
+        });
+        it('returns true if member has no roommates saved and a group members username have been provided', () => {
+            // given
+            const memberRoommates = [];
+
+            const groupMembersUsernames = ['memberA', 'memberB', 'memberC'];
+
+            // when
+            const haveGroupMembersChangedBool = haveGroupMembersChanged(groupMembersUsernames, memberRoommates);
+
+            // then
+            expect(haveGroupMembersChangedBool).toBe(true);
+        });
+        it('returns true if member has roommates saved and a group members usernames have not been provided', () => {
+            // given
+            const memberRoommates = [
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 1,
+                    roommateUsername: 'member1'
+                },
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 3,
+                    roommateUsername: 'member3'
+                },
+                {
+                    MemberAccountUid: 2,
+                    RoommateUid: 4,
+                    roommateUsername: 'member4'
+                }
+            ];
+
+            const groupMembersUsernames = undefined;
+
+            // when
+            const haveGroupMembersChangedBool = haveGroupMembersChanged(groupMembersUsernames, memberRoommates);
+
+            // then
+            expect(haveGroupMembersChangedBool).toBe(true);
+        });
+        it('returns false if member has no partners saved as a roommate and a partner username has not been provided', () => {
+            // given
+            const memberRoommates = [];
+
+            const groupMembersUsernames = undefined;
+
+            // when
+            const haveGroupMembersChangedBool = haveGroupMembersChanged(groupMembersUsernames, memberRoommates);
+
+            // then
+            expect(haveGroupMembersChangedBool).toBe(false);
+        });
+   });
+
+   describe('getRoommatesUsernames', () => {
+       it('should return a list of roommates usernames given a list of roommates', () => {
+           // expected result
+           const expectedUsernames = ['member1', 'member3', 'member4'];
+
+           // given
+           const memberRoommates = [
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 1,
+                   roommateUsername: 'member1'
+               },
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 3,
+                   roommateUsername: 'member3'
+               },
+               {
+                   MemberAccountUid: 2,
+                   RoommateUid: 4,
+                   roommateUsername: 'member4'
+               }
+           ];
+
+           // when
+           const usernamesList = getRoommatesUsernames(memberRoommates);
+
+           // then
+           expect(usernamesList).toEqual(expectedUsernames);
+       });
+       it('should return an empty list if list of roommates is undefined', () => {
+           // expected result
+           const expectedUsernames = [];
+
+           // given
+           const memberRoommates = undefined;
+
+           // when
+           const usernamesList = getRoommatesUsernames(memberRoommates);
+
+           // then
+           expect(usernamesList).toEqual(expectedUsernames);
+       });
+   });
+
+    describe('memberHasCoupleStatus', () => {
+        it.each`
+            status                      | expected
+            ${'Single'}                 | ${false}
+            ${'Couple'}                 | ${true}
+            ${'Couple With Children'}   | ${true}
+            ${'Single Parent'}          | ${false}
+            ${'Existing Group'}         | ${false}
+        `('returns $expected when status is $status',
+            ({ status, expected }) => {
+                expect(memberHasCoupleStatus(status)).toBe(expected);
+            });
+    });
+
+    describe('memberHasExistingGroupStatus', () => {
+        it.each`
+            status                      | expected
+            ${'Single'}                 | ${false}
+            ${'Couple'}                 | ${false}
+            ${'Couple With Children'}   | ${false}
+            ${'Single Parent'}          | ${false}
+            ${'Existing Group'}         | ${true}
+        `('returns $expected when status is $status',
+            ({ status, expected }) => {
+                expect(memberHasExistingGroupStatus(status)).toBe(expected);
+            });
+    });
+
+
+});

--- a/server/controllers/utils/accountControllerUtils.js
+++ b/server/controllers/utils/accountControllerUtils.js
@@ -25,6 +25,15 @@ const getMailingAddress = (body) => {
         }
 }
 
+/**
+ *
+ * @param flag: if this field is true, then the optional field can be defined
+ * @param optionalField
+ */
+const getValueOfOptionalField = (flag, optionalField) => {
+    return flag ? optionalField : null;
+}
+
 const formatPhoneNumber = (phoneNum) => {
     if (!phoneNum || phoneNum.toString().length !== 10 || typeof phoneNum !== 'number') {
         return '';
@@ -101,8 +110,11 @@ const getMemberAccountInfo = member => {
     }
 }
 
+
+
 module.exports = {
     getMailingAddress,
+    getValueOfOptionalField,
     formatPhoneNumber,
     getFilteredProfilesInformation,
     getMemberAccountInfo,

--- a/server/controllers/utils/areaOfInterestUtils.js
+++ b/server/controllers/utils/areaOfInterestUtils.js
@@ -1,0 +1,33 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.01.29
+ *
+ * @Description: utility functions for areas of interest
+ *
+ */
+
+const differenceWith = require('lodash/differenceWith');
+const isEqual = require('lodash/isEqual');
+
+const getListOfAreaOfInterestObjects = areasOfInterest => {
+    if (!areasOfInterest)
+        return [];
+
+    return areasOfInterest.map(areaOfInterest => {
+        return {
+            province: areaOfInterest.province,
+            city: areaOfInterest.city,
+            radius: areaOfInterest.radius
+        }
+    });
+}
+
+const areasOfInterestHaveChanged = (oldAreasOfInterest, newAreasOfInterest) => {
+    return !!differenceWith(oldAreasOfInterest, newAreasOfInterest, isEqual).length
+        || !!differenceWith(newAreasOfInterest, oldAreasOfInterest, isEqual).length;
+}
+
+module.exports = {
+    getListOfAreaOfInterestObjects,
+    areasOfInterestHaveChanged
+}

--- a/server/controllers/utils/statusUtils.js
+++ b/server/controllers/utils/statusUtils.js
@@ -1,0 +1,65 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.01.29
+ *
+ * @Description: utility function to deal with statuses and status changes
+ *
+ */
+
+const get = require('lodash/get');
+const includes = require('lodash/includes');
+const difference = require('lodash/difference');
+const {STATUS} = require('../../constants/memberConstants');
+
+const isStatusWithRoommates = status => {
+    return includes([STATUS.COUPLE, STATUS.COUPLE_WITH_CHILDREN, STATUS.EXISTING_GROUP], status);
+}
+
+const hasPartnerChanged = (partnerUsername, memberRoommates) => {
+    // member does not have partner username linked to their account and is not adding a partner's username
+    if (!partnerUsername && !memberRoommates.length) {
+        return false;
+    }
+
+    return !includes(getRoommatesUsernames(memberRoommates), partnerUsername);
+}
+
+const haveGroupMembersChanged = (existingGroupUsernames, memberRoommates) => {
+    // member does not have any group member usernames linked to their account and they are not adding any
+    if (!existingGroupUsernames && !!memberRoommates.length) {
+        return true;
+    }
+    if ((!existingGroupUsernames || !existingGroupUsernames.length) && !memberRoommates.length) {
+        return false;
+    }
+
+    // checks to see if there are any differences between the list of found usernames and usernames provided
+    return !!difference(existingGroupUsernames, getRoommatesUsernames(memberRoommates)).length
+}
+
+const getRoommatesUsernames = memberRoommates => {
+    if (!memberRoommates) {
+        return [];
+    }
+
+    return memberRoommates.map(
+        roommate => get(roommate, 'roommateUsername', undefined)
+    );
+}
+
+const memberHasCoupleStatus = (status) => {
+    return status === STATUS.COUPLE || status === STATUS.COUPLE_WITH_CHILDREN;
+}
+
+const memberHasExistingGroupStatus = status => {
+    return status === STATUS.EXISTING_GROUP;
+}
+
+module.exports = {
+    isStatusWithRoommates,
+    hasPartnerChanged,
+    memberHasCoupleStatus,
+    memberHasExistingGroupStatus,
+    haveGroupMembersChanged,
+    getRoommatesUsernames
+}

--- a/server/controllers/validators/userControllerValidator.js
+++ b/server/controllers/validators/userControllerValidator.js
@@ -176,6 +176,140 @@ const businessAccountValidation = [
         .stripLow()
 ];
 
+const memberProfileBasicFieldsValidation = [
+    body('gender', 'One of Female, Male, Other must be provided as gender')
+        .exists()
+        .trim()
+        .stripLow()
+        .isIn(GENDERS),
+    body('genderDescription')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('birthYear', 'A valid integer must be provided as year of birth')
+        .exists()
+        .isNumeric(),
+    body('minMonthlyBudget', 'A valid positive integer must be provided for rent')
+        .exists()
+        .isNumeric()
+        .customSanitizer(rent => parseInt(rent))
+        .custom(rent => isPositiveInteger(rent)),
+    body('maxMonthlyBudget', 'A valid positive integer must be provided for rent')
+        .exists()
+        .isNumeric()
+        .customSanitizer(rent => parseInt(rent))
+        .custom(rent => isPositiveInteger(rent))
+        .custom((rent, {req}) => validateMinAndMax(req.body.minMonthlyBudget, rent)),
+    body('hasHomeToShare', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('hasHomeToShareDescription', 'Invalid house description')
+        .optional()
+        .trim()
+        .stripLow(true),
+    body('isReligionImportant', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('religionDescription', 'Invalid description for religion')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('isDietImportant', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('dietDescription', 'Invalid description for diet')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('hasHealthMobilityIssues', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('healthMobilityIssuesDescription', 'Invalid description for health and mobility')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('hasAllergies', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('allergiesDescription', 'Invalid description for allergies')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('hasPets', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('petsDescription', 'Invalid description for allergies')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('isSmoker', 'A boolean value must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isBoolean(),
+    body('smokingDescription', 'Invalid description for allergies')
+        .optional()
+        .trim()
+        .stripLow(),
+    body('numRoommates', 'Must provide a valid value for numRoommates')
+        .exists()
+        .isNumeric()
+        .custom(limit => isValidShareLimit(limit)),
+    body('bio', 'Must provide a valid bio')
+        .optional()
+        .trim()
+        .stripLow(true),
+    body('workStatus')
+        .exists()
+        .trim()
+        .stripLow()
+        .isIn(WORK_STATUSES)
+];
+
+const memberStatusValidation = [
+    body('status', 'A valid status must be provided')
+        .exists()
+        .trim()
+        .stripLow()
+        .isIn(STATUSES),
+    body('partnerUsername', `A valid member's username must be provided for partners`)
+        .optional()
+        .trim()
+        .stripLow()
+        .custom(partnerUsername => usernameShouldExistAndBeAMember(partnerUsername))
+        .custom((partnerUsername, { req }) =>
+            linkedMemberShouldHaveSameStatus(partnerUsername, req)),
+    body('existingGroupUsernames')
+        .optional()
+        .isArray(),
+    // * allows us to test each username in array with custom function
+    body('existingGroupUsernames.*')
+        .optional()
+        .trim()
+        .stripLow()
+        .custom(username => usernameShouldExistAndBeAMember(username))
+        .custom((username, { req }) => linkedMemberShouldHaveSameStatus(username, req)),
+];
+
+const areasOfInterestValidation = [
+    body('areasOfInterest')
+        .exists()
+        .isArray()
+        .custom(areasOfInterest => isValidAreasOfInterest(areasOfInterest))
+];
+
 
 exports.validate = (method) => {
     switch (method) {
@@ -207,132 +341,10 @@ exports.validate = (method) => {
                 ...abstractUserValidation,
                 ...registrationSigninDetailsValidation,
                 ...emailUponRegistrationValidation,
+                ...memberProfileBasicFieldsValidation,
+                ...memberStatusValidation,
+                ...areasOfInterestValidation,
 
-                // member account and profile
-                body('gender', 'One of Female, Male, Other must be provided as gender')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isIn(GENDERS),
-                body('genderDescription')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('birthYear', 'A valid integer must be provided as year of birth')
-                    .exists()
-                    .isNumeric(),
-                body('status', 'A valid status must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isIn(STATUSES),
-                body('minMonthlyBudget', 'A valid positive integer must be provided for rent')
-                    .exists()
-                    .isNumeric()
-                    .customSanitizer(rent => parseInt(rent))
-                    .custom(rent => isPositiveInteger(rent)),
-                body('maxMonthlyBudget', 'A valid positive integer must be provided for rent')
-                    .exists()
-                    .isNumeric()
-                    .customSanitizer(rent => parseInt(rent))
-                    .custom(rent => isPositiveInteger(rent))
-                    .custom((rent, {req}) => validateMinAndMax(req.body.minMonthlyBudget, rent)),
-                body('hasHomeToShare', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('hasHomeToShareDescription', 'Invalid house description')
-                    .optional()
-                    .trim()
-                    .stripLow(true),
-                body('isReligionImportant', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('religionDescription', 'Invalid description for religion')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('isDietImportant', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('dietDescription', 'Invalid description for diet')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('hasHealthMobilityIssues', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('healthMobilityIssuesDescription', 'Invalid description for health and mobility')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('hasAllergies', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('allergiesDescription', 'Invalid description for allergies')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('hasPets', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('petsDescription', 'Invalid description for allergies')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('isSmoker', 'A boolean value must be provided')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isBoolean(),
-                body('smokingDescription', 'Invalid description for allergies')
-                    .optional()
-                    .trim()
-                    .stripLow(),
-                body('numRoommates', 'Must provide a valid value for numRoommates')
-                    .exists()
-                    .isNumeric()
-                    .custom(limit => isValidShareLimit(limit)),
-                body('bio', 'Must provide a valid bio')
-                    .optional()
-                    .trim()
-                    .stripLow(true),
-                body('partnerUsername', `A valid member's username must be provided for partners`)
-                    .optional()
-                    .trim()
-                    .stripLow()
-                    .custom(partnerUsername => usernameShouldExistAndBeAMember(partnerUsername))
-                    .custom((partnerUsername, { req }) => linkedMemberShouldHaveSameStatus(partnerUsername, req)),
-                body('existingGroupUsernames')
-                    .optional()
-                    .isArray(),
-                // * allows us to test each username in array with custom function
-                body('existingGroupUsernames.*')
-                    .optional()
-                    .trim()
-                    .stripLow()
-                    .custom(username => usernameShouldExistAndBeAMember(username))
-                    .custom((username, { req }) => linkedMemberShouldHaveSameStatus(username, req)),
-                body('areasOfInterest')
-                    .exists()
-                    .isArray()
-                    .custom(areasOfInterest => isValidAreasOfInterest(areasOfInterest)),
-                body('workStatus')
-                    .exists()
-                    .trim()
-                    .stripLow()
-                    .isIn(WORK_STATUSES),
                 body('minAgePreference')
                     .exists()
                     .isNumeric()
@@ -407,8 +419,27 @@ exports.validate = (method) => {
                 ...businessAccountValidation
             ]
         }
+        case 'updateMemberAccountInfo': {
+            return [
+                ...emailUponUpdateValidation,
+                ...abstractUserValidation
+            ]
+        }
+        case 'updateMemberProfile': {
+            return [
+                ...memberProfileBasicFieldsValidation
+            ]
+        }
+        case 'updateMemberStatus' : {
+            return [
+                ...memberStatusValidation
+            ]
+        }
+        case 'updateMemberAreasOfInterest':
+            return [
+                ...areasOfInterestValidation
+            ]
         case 'memberSearchFilters': {
-            console.log('validating member search filters');
             return [
                 body('minAgePreference')
                     .optional()

--- a/server/controllers/validators/userControllerValidatorUtils.js
+++ b/server/controllers/validators/userControllerValidatorUtils.js
@@ -10,6 +10,7 @@ const abstractUserController = require('../abstractUserController');
 const memberAccountController = require('../memberAccountController');
 const PasswordService = require('../../services/PasswordService');
 const {isCanadianPostalCode} = require('../utils/locationUtils');
+const {STATUS} = require('../../constants/memberConstants');
 
 const PROVINCES = [
     'AB',
@@ -34,11 +35,11 @@ const GENDERS = [
 ];
 
 const STATUSES = [
-    'Single',
-    'Couple',
-    'Couple With Children',
-    'Single Parent',
-    'Existing Group'
+    STATUS.SINGLE,
+    STATUS.COUPLE,
+    STATUS.COUPLE_WITH_CHILDREN,
+    STATUS.SINGLE_PARENT,
+    STATUS.EXISTING_GROUP
 ];
 
 const SHARE_LIMITS = [1, 2, 3, 4, -1];  // -1 means any number of people
@@ -79,7 +80,6 @@ const isValidPhoneNumber = (phoneNum) => {
 const isValidCanadianPostalCode = (postalCode) => {
     const regex = RegExp('^([A-Za-z]\\d[A-Za-z][-]?\\d[A-Za-z]\\d)');
     if (!regex.test(postalCode)) {
-        console.log(postalCode, ' is an invalid postal code');``
         throw new Error('Invalid postal code');
     } else {
         return true;
@@ -222,7 +222,7 @@ const isValidAreasOfInterest = (areasOfInterest) => {
 const usernameShouldNotAlreadyExist = (username) =>
     abstractUserController.findUserByUsername(username)
         .then(user => {
-            if (user.length) {
+            if (user) {
                 return Promise.reject('User already exists');
             }
         });
@@ -230,7 +230,6 @@ const usernameShouldNotAlreadyExist = (username) =>
 const emailShouldNotAlreadyBeInUse = (email) =>
     abstractUserController.findUserByEmail(email)
         .then(user => {
-            console.log('user: ', user);
             if (user.length) {
                 return Promise.reject('Email already in use');
             }
@@ -248,7 +247,7 @@ const updatedEmailShouldNotAlreadyBeInUse = (email, req) => {
 const usernameShouldExist = (username) =>
     abstractUserController.findUserByUsername(username)
         .then(user => {
-            if (!user.length) {
+            if (!user) {
                 return Promise.reject('Username does not exist');
             }
         });
@@ -305,9 +304,8 @@ const providedNewPasswordShouldNotMatchExistingPassword = (password, uid) => {
 
 const correctPasswordForUsername = (username, password) =>
     abstractUserController.findUserByUsername(username)
-        .then(users => {
-            if (users.length) {
-                const user = users[0].dataValues;
+        .then(user => {
+            if (user) {
                 const hashedPassword = PasswordService.getHashedPassword(password, user.salt);
 
                 if (hashedPassword !== user.password) {


### PR DESCRIPTION
# [HTC-366](https://github.com/rachellegelden/Home-Together-Canada/issues/<366>) & [HTC-367](https://github.com/rachellegelden/Home-Together-Canada/issues/<366>) 

## Summary
- Added the routes that will be used to update members' account info and profile. This consists of 4 main parts:
  - update the member's info (this is mainly the values stored in abstract user)
  - update the basic fields of the fields of the member's profile (ie. these are the fields stored in member account table)
  - update the member's status. Depending on the status, this may require updates to the LivesWiths table (where we keep track of roommates)
  - update areas of interest. This requires updates to the areaOfInterest table
- Added the areas of interest and the roommates for a member to the `member/profile` route (I missed this in #409)

## Relevant Motivation & Context
This will be used in the members account summary portion of the site to update their information

## Testing Instructions
### Testing updating member's account info
1. create a user
2. using Postman, send a `POST`  request to `http://localhost:3001/member/info/update/` with the following body:
```
{
    "email": "member1@gelden.com",
    "firstName": "Rachelle",
    "lastName": "Gelden",
    "phoneNumber": 4033365156,
    "addressLine1": "1 Oak Ave",
    "city": "Kelowna",
    "province": "BC",
    "postalCode": "T1V1S4",
    "hasDifferentMailingAddress": false
}
```
Feel free to change the values.
4. Next send a `GET` request to `http://localhost:3001/member/info/` and make sure that the updates to the member's info is as expected

### Testing updating a member's profile
1. send a `POST` request to `http://localhost:3001/member/profile/update/` with the following body:
```
{
    "gender": "Female",
    "birthYear": 1998,
    "status": "Couple",
    "workStatus": "Retired",
    "minMonthlyBudget": 500,
    "maxMonthlyBudget": 950,
    "hasHomeToShare": false,
    "isReligionImportant": false,
    "isDietImportant": false,
    "hasHealthMobilityIssues": false,
    "hasAllergies": false,
    "hasPets": false,
    "isSmoker": false,
    "numRoommates": 1
}
```
Feel free to change the values.
4. Next send a `GET` request to `http://localhost:3001/member/profile/` and make sure that the updates to the member's info is as expected

### Testing updating users status
The basic process for updating the status is as follows:
1. make sure that you are logged in -  send a `POST` request to `http://localhost:3001/user/login/` with the following body:
```
{
    "username": "member2",
    "password": "Password123"
}
```
2. send a `POST` request to `http://localhost:3001/member/profile/status/update/` with the following body:
```
{
    "status": "Existing Group",
    "existingGroupUsernames": ["member4", "member5"]
}
```
Note: if you are changing the status to `Couple` or `Couple With Children`, then `existingGroupUsernames` should be `partnerUsername`. 
3. send a `GET` request to `http://localhost:3001/roommates/` and make sure that you see the expected roommates in the list
4.  Next send a `GET` request to `http://localhost:3001/member/profile/` and make sure that the status is what you expect it to be. 

The following cases must be tested (note that each `X.X` is its own separate case and each must be tested. This will require making several accounts and will probably require dropping the DB).
```
case 2 - was a couple but there was a change
// 2.1 covers status changed from couple to existing group
	// delete entry from LivesWith, add new entry to LivesWiths

// 2.2 was a couple, now a different kind of couple
	// delete entry from LivesWith, add new entry to LivesWith

// 2.3 was a couple, now isn't a couple or an EG
	// delete entry from LivesWith

// 2.4 still is a couple, but the partner's username has changed (this should cover removing the partner's username)
	// delete entry from LivesWith, add new entry to LivesWith
	
// 2.5 still a couple but partner's username has been removed
	// delete entry from LivesWiths

// case 3 - old status was EG, but there has been a change
// 3.1 was an EG now is a couple
	// delete entry from LivesWith, add new entries to LivesWith

// 3.2 was an EG, now is a non-couple status
	// delete entry from LivesWith

// 3.3 still is EG, but the group member usernames have changed (this should cover removing the group members' usernames)
	// delete entries from LivesWith, add new entries to LivesWith
	
// 3.4 still EG but usernames have been removed	
	// delete entries from LivesWiths

// case 4 - was a non EG/couple, but there has been a change
// 4.1 now is an EG
	// add new entries to LivesWith

// 4.2 now is couple
	// add new entry to LivesWith

// 4.3 now is a different non EG/couple status
	// just update the status
```

### Testing updating areas of interested
1. create a member (it is easiest if you drop the DB before starting testing this task, this will keep things less cluttered and easier to read)
2. send a `POST` request to `http://localhost:3001/member/profile/areasOfInterest/update/` with the following body:
```
{
    "areasOfInterest": [{"province": "AB", "city": "High River", "radius": 80}]    
}
```
3. send a `GET` request to `http://localhost:3001/areasOfInterest/` and make sure that areas of interest updated as expected

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [x] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [x] Checkout and launch this branch locally
- [x] Review code structure
- [x] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
