### PR TITLE
HTC-463: Search Filters Subpage Functionality

### DIFF
--- a/client/src/accountSummary/member/SearchCriteria.js
+++ b/client/src/accountSummary/member/SearchCriteria.js
@@ -42,7 +42,6 @@ function SearchCriteria(props) {
         handleSelectedLimitPreferenceChange,
         selectedLimitPreferenceError,
 
-
         minBudgetPreference,
         setMinBudgetPreference,
         minBudgetPreferenceError,
@@ -70,6 +69,8 @@ function SearchCriteria(props) {
         homeToSharePreference,
         setHomeToSharePreference,
         homeToSharePreferenceError,
+
+        showSuccessMessage,
 
         onSubmit,
     } = props;
@@ -267,6 +268,9 @@ function SearchCriteria(props) {
                     </div>
                 </div>
             </div>
+            {showSuccessMessage &&
+                <section className={'success-msg mb-4 justify-center'}>Account info successfully updated!</section>
+            }
             <SubmitButton
                 inputValue={"Save"}
                 className="btn btn-green form-btn w-1/2"
@@ -325,6 +329,8 @@ SearchCriteria.propTypes = {
     homeToSharePreference: PropTypes.string,
     setHomeToSharePreference: PropTypes.func,
     homeToSharePreferenceError: PropTypes.bool,
+
+    showSuccessMessage: PropTypes.bool.isRequired,
 
     onSubmit: PropTypes.func,
 };

--- a/client/src/accountSummary/member/__tests__/SearchCriteria.test.js
+++ b/client/src/accountSummary/member/__tests__/SearchCriteria.test.js
@@ -69,6 +69,8 @@ describe('SearchCriteria', () => {
                 setHomeToSharePreference: jest.fn(),
                 homeToSharePreferenceError: true,
 
+                showSuccessMessage: false,
+
                 onSubmit: jest.fn(),
             }
 

--- a/client/src/services/MemberService.js
+++ b/client/src/services/MemberService.js
@@ -102,3 +102,24 @@ export const updateMemberAreasOfInterest = areasOfInterest => {
     };
     return fetch(`${DEV_URL}/member/profile/areasOfInterest/update/`, request);
 }
+
+export const getMemberSearchFilters = () =>
+    fetch(`${DEV_URL}/member/filters/`, {
+        method: 'GET',
+        withCredentials: true,
+        credentials: 'include'
+    });
+
+export const updateMemberSearchFilters = searchFilters => {
+    const request = {
+        method: 'POST',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        withCredentials: true,
+        body: JSON.stringify(searchFilters)
+    }
+    return fetch(`${DEV_URL}/member/filters/update/`, request);
+}

--- a/server/app.js
+++ b/server/app.js
@@ -50,7 +50,7 @@ require("./config/passport.js")(passport);
 
 
 // force false will prevent the database from being cleared everytime the server starts up
-db.sequelize.sync({ force: false })
+db.sequelize.sync({ force: true })
     .then(() => {
       console.log("Drop and re-sync db.");
     })

--- a/server/controllers/memberAccountController.js
+++ b/server/controllers/memberAccountController.js
@@ -279,6 +279,49 @@ const updateMemberAreaOfInterest = async (req) => {
 
 }
 
+const getMemberSearchFilters = uid => {
+    return MemberAccount.findOne({
+        attributes: [
+            'minAgePreference',
+            'maxAgePreference',
+            'statusPreference',
+            'numRoommatesPreference',
+            'minBudgetPreference',
+            'maxBudgetPreference',
+            'dietPreference',
+            'petsPreference',
+            'smokingPreference',
+            'genderPreference',
+            'religionPreference',
+            'othersWithHomeToSharePreference'
+        ],
+        where: {
+            uid: uid
+        }
+    });
+}
+
+const updateMemberSearchFilters = (uid, req) => {
+    return MemberAccount.update({
+        minAgePreference: req.body.minAgePreference,
+        maxAgePreference: req.body.maxAgePreference,
+        minBudgetPreference: req.body.minBudgetPreference,
+        maxBudgetPreference: req.body.maxBudgetPreference,
+        statusPreference: JSON.stringify(req.body.statusPreference),
+        numRoommatesPreference: JSON.stringify(req.body.numRoommatesPreference),
+        dietPreference: req.body.dietPreference,
+        petsPreference: req.body.petsPreference,
+        smokingPreference: req.body.smokingPreference,
+        genderPreference: JSON.stringify(req.body.genderPreference),
+        religionPreference: req.body.religionPreference,
+        othersWithHomeToSharePreference: req.body.othersWithHomeToSharePreference
+    }, {
+        where: {
+            uid: uid
+        }
+    })
+}
+
 const getMemberProfilesMatchingSearchFilters = (uid, searchFilters) => {
     let query = {
         where: {
@@ -383,5 +426,7 @@ module.exports = {
     updateMemberStatus,
     updateMemberStatusAndRoommates,
     updateMemberAreaOfInterest,
+    getMemberSearchFilters,
+    updateMemberSearchFilters,
     getMemberProfilesMatchingSearchFilters
 }

--- a/server/controllers/validators/userControllerValidator.js
+++ b/server/controllers/validators/userControllerValidator.js
@@ -292,6 +292,57 @@ const memberProfileBasicFieldsValidation = [
         .isIn(WORK_STATUSES)
 ];
 
+const memberSearchFiltersValidation = [
+    body('minAgePreference')
+        .exists()
+        .isNumeric()
+        .custom(age => isPositiveInteger(age)),
+    body('maxAgePreference')
+        .exists()
+        .isNumeric()
+        .custom(age => isPositiveInteger(age))
+        .custom((age, { req }) => validateMinAndMax(req.body.minAgePreference, age)),
+    body('minBudgetPreference')
+        .exists()
+        .isNumeric()
+        .custom(budget => isPositiveInteger(budget)),
+    body('maxBudgetPreference')
+        .exists()
+        .isNumeric()
+        .custom(budget => isPositiveInteger(budget))
+        .custom((budget, {req}) => validateMinAndMax(req.body.minBudgetPreference, budget)),
+    body('statusPreference')
+        .exists()
+        .isArray()
+        .custom(statusPreference => validStatusPreferences(statusPreference)),
+    body('numRoommatesPreference')
+        .exists()
+        .isArray()
+        .custom(limits => isValidShareLimitArray(limits)),
+    body('numRoommatesPreference.*')
+        .isNumeric()
+        .custom(limit => isValidShareLimit(limit)),
+    body('dietPreference')
+        .exists()
+        .isBoolean(),
+    body('petsPreference')
+        .exists()
+        .isBoolean(),
+    body('smokingPreference')
+        .exists()
+        .isBoolean(),
+    body('genderPreference')
+        .exists()
+        .isArray()
+        .custom(genderPreferences => validGenderPreferences(genderPreferences)),
+    body('religionPreference')
+        .exists()
+        .isBoolean(),
+    body('othersWithHomeToSharePreference')
+        .exists()
+        .isBoolean()
+]
+
 const memberStatusValidation = [
     body('status', 'A valid status must be provided')
         .exists()
@@ -358,55 +409,7 @@ exports.validate = (method) => {
                 ...memberProfileBasicFieldsValidation,
                 ...memberStatusValidation,
                 ...areasOfInterestValidation,
-
-                body('minAgePreference')
-                    .exists()
-                    .isNumeric()
-                    .custom(age => isPositiveInteger(age)),
-                body('maxAgePreference')
-                    .exists()
-                    .isNumeric()
-                    .custom(age => isPositiveInteger(age))
-                    .custom((age, { req }) => validateMinAndMax(req.body.minAgePreference, age)),
-                body('minBudgetPreference')
-                    .exists()
-                    .isNumeric()
-                    .custom(budget => isPositiveInteger(budget)),
-                body('maxBudgetPreference')
-                    .exists()
-                    .isNumeric()
-                    .custom(budget => isPositiveInteger(budget))
-                    .custom((budget, {req}) => validateMinAndMax(req.body.minBudgetPreference, budget)),
-                body('statusPreference')
-                    .exists()
-                    .isArray()
-                    .custom(statusPreference => validStatusPreferences(statusPreference)),
-                body('numRoommatesPreference')
-                    .exists()
-                    .isArray()
-                    .custom(limits => isValidShareLimitArray(limits)),
-                body('numRoommatesPreference.*')
-                    .isNumeric()
-                    .custom(limit => isValidShareLimit(limit)),
-                body('dietPreference')
-                    .exists()
-                    .isBoolean(),
-                body('petsPreference')
-                    .exists()
-                    .isBoolean(),
-                body('smokingPreference')
-                    .exists()
-                    .isBoolean(),
-                body('genderPreference')
-                    .exists()
-                    .isArray()
-                    .custom(genderPreferences => validGenderPreferences(genderPreferences)),
-                body('religionPreference')
-                    .exists()
-                    .isBoolean(),
-                body('othersWithHomeToSharePreference')
-                    .exists()
-                    .isBoolean()
+                ...memberSearchFiltersValidation
             ]
         }
         case 'changePassword': {
@@ -453,7 +456,12 @@ exports.validate = (method) => {
             return [
                 ...areasOfInterestValidation
             ]
-        case 'memberSearchFilters': {
+        case 'updateMemberSearchFilters':
+            return [
+                ...memberSearchFiltersValidation
+            ];
+
+        case 'memberSearchRequest': {
             return [
                 body('minAgePreference')
                     .optional()

--- a/server/routes/memberRoutes.js
+++ b/server/routes/memberRoutes.js
@@ -187,11 +187,39 @@ router.get('/profile/',
     }
 );
 
+router.post('/filters/update/',
+    isLoggedIn,
+    userIsMember,
+    usersValidator.validate('updateMemberSearchFilters'),
+    function (req, res, next) {
+        memberAccounts.updateMemberSearchFilters(req.user.uid, req)
+            .then(data => {
+                if (data && data.length) {
+                    res.status(202).json({ success: true });
+                } else {
+                    res.status(202).json()
+                }
+            })
+            .catch(err => {
+                res.status(500).json({ err: err.message });
+            })
+    }
+);
+
+router.get('/filters/', isLoggedIn, userIsMember, function(req, res, next) {
+    memberAccounts.getMemberSearchFilters(req.user.uid)
+        .then(searchFilters => {
+            res.json({ ...searchFilters.dataValues });
+        })
+        .catch(err => {
+            res.json({ err: err.message });
+        })
+});
 
 router.post('/search/profiles/',
     isLoggedIn,
     userIsMember,
-    usersValidator.validate('memberSearchFilters'),
+    usersValidator.validate('memberSearchRequest'),
     function (req, res, next) {
         const errors = validationResult(req);
 


### PR DESCRIPTION
# [HTC-463](https://github.com/rachellegelden/Home-Together-Canada/issues/463)

## Summary
- when a member navigates to the search criteria subpage, their personalized search filters are loaded into the form
- member can update their search filters

## Relevant Motivation & Context
This is a part of finishing the account summary epic

## Testing Instructions
- create a member
- go to Search Criteria subpage, make sure correct information is loaded into form
- try updating form search filters
- make sure that updated changes are persisted

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [x] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
