### PR TITLE
HTC-678: search business listings

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -54,7 +54,7 @@ require("./config/passport.js")(passport);
 
 
 // force false will prevent the database from being cleared everytime the server starts up
-db.sequelize.sync({ force: true })
+db.sequelize.sync({ force: false })
     // populate DB with categories and subcategories
     .then(() => {
         return listingCategories.populateDBWithCategories();

--- a/server/controllers/listingController.js
+++ b/server/controllers/listingController.js
@@ -9,11 +9,15 @@ const filter = require('lodash/filter');
 const booleanPointInPolygon = require('@turf/boolean-point-in-polygon').default;
 const point = require('@turf/helpers').point;
 const polygon = require('@turf/helpers').polygon;
+const { Op } = require("sequelize");
 
 const db = require('../models');
 const Listing = db.listing;
 const ListingCategory = db.listingCategory;
 const MemberListingLocation = db.memberListingLocation;
+const ListingSubcategory = db.listingSubcategory;
+const AbstractUser = db.abstractUser;
+const BusinessAccount = db.businessAccount;
 
 const { LISTING_TYPES } = require('../controllers/validators/listingControllerValidatorUtils');
 const { getListingFields } = require('./utils/listingControllerUtils');
@@ -78,6 +82,9 @@ const searchMemberServiceListings = async (searchArea, categoryName) => {
         include: [
             {
                 model: ListingCategory,
+                where: {
+                    name: categoryName
+                }
             },
             {
                 model: MemberListingLocation
@@ -103,9 +110,90 @@ const searchMemberServiceListings = async (searchArea, categoryName) => {
     return filteredLocations;
 }
 
+const searchBusinessListings = async (searchArea, categoryName, subcategoryNames) => {
+    const businessListings = await Listing.findAll({
+        where: {
+            isDeleted: false,
+            // TODO:  remove equal null option when implementing admin portal
+            dateAdminApproved: {
+                [Op.or]: {
+                    [Op.gt]: new Date(),
+                    [Op.eq]: null
+                }
+            },
+            dateExpired: {
+                [Op.or]: {
+                    [Op.eq]: null,
+                    [Op.lt]: new Date()
+                }
+            }
+        },
+        include: [
+            {
+                model: ListingCategory,
+                where: {
+                    name: categoryName,
+                },
+                include: [
+                    {
+                        model: ListingSubcategory,
+                        where: {
+                            name: subcategoryNames
+                        }
+                    }
+                ]
+            },
+            {
+                model: AbstractUser,
+                attributes: ['username', 'email'],
+                include: [
+                    {
+                        model: BusinessAccount
+                    }
+                ]
+            }
+        ]
+    });
+
+    const searchAreaFeature = await getCircularFeatureFromLocation(searchArea.province, searchArea.city, searchArea.radius);
+
+    const businessListingsFilteredByLocation = filter(businessListings, function (listing) {
+        if (listing.AbstractUser.BusinessAccount.isNationWide) {
+            return true;
+        }
+        const pointObj = point([
+            parseFloat(listing.AbstractUser.BusinessAccount.mapLongitude),
+            parseFloat(listing.AbstractUser.BusinessAccount.mapLatitude)
+        ]);
+        const polygonObj = polygon(searchAreaFeature.geometry.coordinates);
+
+        return booleanPointInPolygon(
+            pointObj,
+            polygonObj
+        );
+    });
+
+    return businessListingsFilteredByLocation.map(listing => {
+        return {
+            id: listing.id,
+            uid: listing.uid,
+            ...(JSON.parse(listing.fields)),
+            isClassified: listing.isClassified,
+            createdAt: listing.createdAt,
+            updatedAt: listing.updatedAt,
+            business: {
+                username: listing.AbstractUser.dataValues.username,
+                email: listing.AbstractUser.dataValues.email,
+                ...listing.AbstractUser.BusinessAccount.dataValues,
+            }
+        }
+    });
+}
+
 module.exports = {
     createListing,
     findAllListings,
-    searchMemberServiceListings
+    searchMemberServiceListings,
+    searchBusinessListings
 }
 

--- a/server/controllers/memberAccountController.js
+++ b/server/controllers/memberAccountController.js
@@ -16,7 +16,6 @@ const {getValueOfOptionalField} = require("./utils/accountControllerUtils");
 const MemberAccount = db.memberAccount;
 const AbstractUser = db.abstractUser;
 const AreaOfInterest = db.areaOfInterest;
-const LivesWith = db.livesWith;
 const livesWith = require('../controllers/livesWithController');
 const abstractUsers = require('../controllers/abstractUserController');
 const areasOfInterest = require('../controllers/areaOfInterestController');

--- a/server/controllers/validators/userControllerValidatorUtils.js
+++ b/server/controllers/validators/userControllerValidatorUtils.js
@@ -143,13 +143,17 @@ const validateMapProvince = (province, req) => {
 }
 
 const validMapAddress = (addressLine1, req) => {
-    const address = `${addressLine1} ${req.body.mapCity} ${PROVINCE_MAP.get(req.body.mapProvince)} ${DEFAULT_COUNTRY}`;
-    return geoCoder.geocode(address)
-        .then(locations => {
-            if (!locations.length) {
-                return Promise.reject('Invalid map address');
-            }
-        });
+    if (!req.body.isNationWide) {
+        const address = `${addressLine1} ${req.body.mapCity} ${PROVINCE_MAP.get(req.body.mapProvince)} ${DEFAULT_COUNTRY}`;
+        return geoCoder.geocode(address)
+            .then(locations => {
+                if (!locations.length) {
+                    return Promise.reject('Invalid map address');
+                }
+            });
+    } else {
+        return true;
+    }
 }
 
 const shouldIncorporatedOwnersNamesBeDefined = (incorporatedOwnersNames, req) => {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -43,6 +43,13 @@ db.businessAccount.belongsTo(db.abstractUser, {
     },
     onDelete: 'CASCADE'
 });
+db.abstractUser.hasOne(db.businessAccount, {
+    foreignKey: {
+        name: 'uid',
+        allowNull: false
+    },
+    onDelete: 'CASCADE'
+});
 
 db.memberAccount.belongsTo(db.abstractUser, {
     foreignKey: {
@@ -61,6 +68,7 @@ db.memberAccount.hasMany(db.areaOfInterest, {
     onDelete: 'CASCADE'
 });
 
+// relationship between listings and abstract users
 db.listing.belongsTo(db.abstractUser, {
     foreignKey: {
         name: 'uid',
@@ -68,24 +76,39 @@ db.listing.belongsTo(db.abstractUser, {
     },
     onDelete: 'CASCADE'
 });
+db.abstractUser.hasMany(db.listing, {
+    onDelete: 'CASCADE'
+});
 
+// relationship between listings and categories
 db.listing.belongsTo(db.listingCategory, {
     onDelete: 'CASCADE'
 });
-
-db.listingSubcategory.belongsTo(db.listingCategory, {
+db.listingCategory.hasMany(db.listing, {
     onDelete: 'CASCADE'
 });
 
+// relationship between categories and subcategories
+db.listingSubcategory.belongsTo(db.listingCategory, {
+    onDelete: 'CASCADE'
+});
+db.listingCategory.hasMany(db.listingSubcategory), {
+    onDelete: 'CASCADE'
+};
+
+// Through table for listings and subcategories
 db.listingSubcategory.belongsToMany(db.listing, {
     through: db.listingAssignedSubcategory,
 });
-
-db.listingSubcategory.belongsToMany(db.listing, {
+db.listing.belongsToMany(db.listingSubcategory, {
     through: db.listingAssignedSubcategory
 });
 
+// Relationship between member listing locations and listings
 db.listing.hasOne(db.memberListingLocation, {
+    onDelete: 'CASCADE'
+});
+db.memberListingLocation.belongsTo(db.listing, {
     onDelete: 'CASCADE'
 });
 

--- a/server/routes/listingRoutes.js
+++ b/server/routes/listingRoutes.js
@@ -157,7 +157,13 @@ router.post('/search/', listingValidator.validate(LISTING_VALIDATION_METHODS.SEA
                     })
             } else {
                 // do a business listing search
-                res.json({ msg: 'Searching business listings is not implemented yet'});
+                listingController.searchBusinessListings(req.body.searchArea, req.body.category, req.body.subcategories)
+                    .then(listings => {
+                        res.status(200).json({ listings });
+                    })
+                    .catch(err => {
+                        res.status(500).json({ err: err.message });
+                    });
             }
         }
     }


### PR DESCRIPTION
# [HTC-678](https://github.com/rachellegelden/Home-Together-Canada/issues/678)

## Summary
- Users can now search for business listings through Postman
- Fixed the invalid map address bug in business registration/update when `isNationWide` is set to `true`
- Slightly adjusted the DB schema (only the relationships between tables - see `server/models/index.js`)

## Relevant Motivation & Context
This will be used as the functionality for search listings

## Testing Instructions
- Create some businesses (make sure to have a few businesses set `isNationWide: true`)
- For each of the businesses, have them create a few listings
- ping the following route with a `POST` request `http://localhost:3001/listing/search/` with the follow body:
```
{
    "type": "service",
    "category": "Cohousing, Co-ops, Intergenerational & Planned Neighbourhoods",
    "subcategories": ["Co-housing Groups & Communities", "Cooperatives", "Communal Living"],
    "searchArea": {
        "province": "AB",
        "city": "High River",
        "radius": 50
    }
}
```
- try different searches with different locations, categories and subcategories

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
