### PR TITLE
HTC-588: added route to make first admin

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ const businessRoutes = require('./routes/businessRoutes');
 const memberRoutes = require('./routes/memberRoutes');
 const userRoutes = require('./routes/userRoutes');
 const listingRoutes = require('./routes/listingRoutes');
+const adminRoutes = require('./routes/adminRoutes');
 const db = require("./models");
 const listingCategories = require('./controllers/listingCategoryController');
 const listingSubcategories = require('./controllers/listingSubcategoryController');
@@ -46,7 +47,8 @@ app.use(passport.session()); // persistent login sessions
 app.use('/user', userRoutes);
 app.use('/business', businessRoutes);
 app.use('/member', memberRoutes);
-app.use('/listing', listingRoutes)
+app.use('/listing', listingRoutes);
+app.use('/admin', adminRoutes);
 app.use('/', routes);
 
 //load passport strategies

--- a/server/controllers/memberAccountController.js
+++ b/server/controllers/memberAccountController.js
@@ -503,6 +503,16 @@ const getMemberProfilesMatchingSearchFilters = async (uid, searchFilters, filter
     return profilesFilteredByLocation;
 }
 
+const giveAdminPrivileges = uid => {
+    return MemberAccount.update({
+        isAdmin: true
+    }, {
+        where: {
+            uid: uid
+        }
+    });
+}
+
 module.exports = {
     createMemberAccount,
     findAllMemberAccounts,
@@ -517,5 +527,6 @@ module.exports = {
     updateMemberSearchFilters,
     getMemberProfilesMatchingSearchFilters,
     activateAccount,
-    deactivateAccount
+    deactivateAccount,
+    giveAdminPrivileges
 }

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -1,0 +1,33 @@
+/**
+ * @Author:     Rachelle Gelden
+ * @Created:    2021.03.09
+ *
+ * @Description: all routes for requests related to admins users
+ *
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { isLoggedIn, userIsMember } = require('./routeUtils');
+const memberAccounts = require('../controllers/memberAccountController');
+
+router.get('/dev/create/',
+    isLoggedIn,
+    userIsMember,
+    function (req, res, next) {
+        memberAccounts.giveAdminPrivileges(req.user.uid)
+            .then(data => {
+                if (data.length) {
+                    res.status(200).json({ adminPrivileges: true });
+                } else {
+                    res.status(500).json({ err: `Failed to give user with id ${req.user.uid} admin privileges`});
+                }
+            })
+            .catch(err => {
+                res.status(500).json({ err });
+            });
+    }
+);
+
+module.exports = router;


### PR DESCRIPTION
# [HTC-588](https://github.com/rachellegelden/Home-Together-Canada/issues/588)

## Summary
Added initial route that will be used to make the first admin

## Relevant Motivation & Context
We need a route to make the first admin so that that admin can make other admins

## Testing Instructions
1. Create a member
2. Using postman (make sure you're logged in to that member you just made on postman) ping `http://localhost:3001/admin/dev/create/` with a `GET` request
3. login on the website with that member and make sure the admin button shows up in the header

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
