### PR TITLE
HTC-738: ban user route

### DIFF
--- a/server/controllers/abstractUserController.js
+++ b/server/controllers/abstractUserController.js
@@ -113,6 +113,16 @@ const updateAbstractUser = (req, res) => {
     });
 }
 
+const banUser = uid => {
+    return AbstractUser.update({
+        isBanned: true
+    }, {
+        where: {
+            uid: uid
+        }
+    });
+}
+
 module.exports = {
     createAbstractUser,
     findAllAbstractUsers,
@@ -122,5 +132,6 @@ module.exports = {
     findUserByEmail,
     changePassword,
     updateAbstractUser,
-    deleteAccount
+    deleteAccount,
+    banUser
 }

--- a/server/controllers/listingController.js
+++ b/server/controllers/listingController.js
@@ -203,10 +203,21 @@ const searchBusinessListings = async (searchArea, categoryName, subcategoryNames
     });
 }
 
+const softDeleteListings = uid => {
+    return Listing.update({
+        isDeleted: true
+    }, {
+        where: {
+            uid: uid
+        }
+    })
+}
+
 module.exports = {
     createListing,
     findAllListings,
     searchMemberServiceListings,
-    searchBusinessListings
+    searchBusinessListings,
+    softDeleteListings
 }
 

--- a/server/controllers/memberAccountController.js
+++ b/server/controllers/memberAccountController.js
@@ -469,7 +469,10 @@ const getMemberProfilesMatchingSearchFilters = async (uid, searchFilters, filter
         include: [
             {
                 model: AbstractUser,
-                attributes: ['username']
+                attributes: ['username'],
+                where: {
+                    isBanned: false
+                }
             },
             {
                 model: AreaOfInterest

--- a/server/controllers/validators/userControllerValidator.js
+++ b/server/controllers/validators/userControllerValidator.js
@@ -560,5 +560,14 @@ exports.validate = (method) => {
                     .custom(username => usernameShouldExistAndBeAMember(username))
             ]
         }
+        case 'banUser': {
+            return [
+                body('username')
+                    .exists()
+                    .trim()
+                    .stripLow()
+                    .custom(username => usernameShouldExist(username))
+            ]
+        }
     }
 }

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -11,6 +11,9 @@ const router = express.Router();
 
 const { isLoggedIn, userIsMember, userIsAdmin } = require('./routeUtils');
 const memberAccounts = require('../controllers/memberAccountController');
+const abstractUsers = require('../controllers/abstractUserController');
+const listings = require('../controllers/listingController');
+const usersValidator = require('../controllers/validators/userControllerValidator');
 const { getUsernameFromAbstractUser } = require('../controllers/utils/accountControllerUtils');
 
 // NOTE: this route is only for development purposes as a means to make the first admin
@@ -36,6 +39,7 @@ router.get('/dev/create/',
 router.post('/create/',
     isLoggedIn,
     userIsAdmin,
+    usersValidator.validate('grantAdminPrivileges'),
     async function (req, res, next) {
         // get the uid for the given username
         const member = await memberAccounts.findMemberAccountByUsername(req.body.username);
@@ -68,6 +72,30 @@ router.get('/all/',
             .catch(err => {
                 res.status(500).json({ err: err.message });
             })
+    }
+);
+
+router.post('/ban/user/',
+    isLoggedIn,
+    userIsAdmin,
+    usersValidator.validate('banUser'),
+    async function (req, res, next) {
+    // get uid
+        const user = await abstractUsers.findUserByUsername(req.body.username);
+        const uid = user.uid;
+
+        // set isBanned to true
+        abstractUsers.banUser(uid)
+            .then(() => {
+                // soft delete listings
+                return listings.softDeleteListings(uid);
+            })
+            .then(() => {
+                res.status(200).json({ success: true });
+            })
+            .catch(err => {
+                res.status(500).json({ err: err.message });
+            });
     }
 );
 


### PR DESCRIPTION
# [HTC-738](https://github.com/rachellegelden/Home-Together-Canada/issues/738)

## Summary
- added route that will ban a user (member or business)
- if the banned user is a member, they will not be showed in the member search
- the listings of the banned user will be soft deleted (are not permanently deleted from the DB, but will no longer be showed when searching services and classifieds)

## Relevant Motivation & Context
Will be used in admin portal

## Testing Instructions
- make an admin user
- make a normal member user
- ban that new member while logged in to the admin
- make sure they don't show up in the member search
- make a business user
- make a few listings attached to that business user
- ban that business user
- make sure their listings don't show up

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
