### PR TITLE
HTC-739: route that lists usernames of all banned users

### DIFF
--- a/server/controllers/abstractUserController.js
+++ b/server/controllers/abstractUserController.js
@@ -123,6 +123,15 @@ const banUser = uid => {
     });
 }
 
+const listBannedUsers = () => {
+    return AbstractUser.findAll({
+        attributes: ['username'],
+        where: {
+            isBanned: true
+        }
+    });
+}
+
 module.exports = {
     createAbstractUser,
     findAllAbstractUsers,
@@ -133,5 +142,6 @@ module.exports = {
     changePassword,
     updateAbstractUser,
     deleteAccount,
-    banUser
+    banUser,
+    listBannedUsers
 }

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -71,7 +71,7 @@ router.get('/all/',
             })
             .catch(err => {
                 res.status(500).json({ err: err.message });
-            })
+            });
     }
 );
 
@@ -98,5 +98,22 @@ router.post('/ban/user/',
             });
     }
 );
+
+router.get('/banned/users/',
+    isLoggedIn,
+    userIsAdmin,
+    function (req, res, next) {
+        abstractUsers.listBannedUsers()
+            .then(bannedUsers => {
+                const formattedListBannedUsers = bannedUsers.map(bannedUser => bannedUser.username);
+                res.status(200).json({ bannedUsers: formattedListBannedUsers });
+            })
+            .catch(err => {
+                res.status(500).json({ err: err.message });
+            });
+    }
+);
+
+
 
 module.exports = router;


### PR DESCRIPTION
# [HTC-739](https://github.com/rachellegelden/Home-Together-Canada/issues/739)

## Summary
- route that returns the usernames of all banned users

## Relevant Motivation & Context
Will be used in admin portal

## Testing Instructions
- make sure you have some banned users
- login as admin
- ping `http://localhost:3001/admin/banned/users/` with a `GET` request
- make sure the users banned are listed there

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
